### PR TITLE
feat: skill bundling + Samantha integration (closes #10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           L3_REQUIRE_TARGETS: production
         run: pnpm test:e2e
 
+      - name: Matrix runner (production strict)
+        run: pnpm test:matrix
+
       - name: Full Test Suite
         run: pnpm test
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 dist/
 .DS_Store
 
+# Composed output
+.cursor/agents/
+.cursor/skills/
+

--- a/README.md
+++ b/README.md
@@ -219,9 +219,15 @@ subagent-harness uses **git tags and GitHub Releases** as the primary version si
 
 ---
 
-## Samantha Mini-Test
+## Community Integrations & Examples
 
-A small integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (emotional AI companion from *Her*) into subagent-harness:
+The vision of `subagent-harness` is to be the universal compiler for open-source AI agent patterns. You can take any popular prompt or structured agent from the community, wrap it in a `.agent.md`, and deploy it everywhere.
+
+### 1. Community Prompts (e.g., awesome-cursorrules)
+Instead of manually copying flat rules from repositories like [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) or [instructa/ai-prompts](https://github.com/instructa/ai-prompts) into your `.cursorrules`, you can define them as `.agent.md` files. This allows you to manage and update community rules centrally, while the harness injects them natively into Cursor, Claude Code, or any other supported tool.
+
+### 2. Samantha Mini-Test
+A structural test integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (an emotional AI companion from *Her* with specific memory constraints, skills, and conversational parameters) into subagent-harness:
 
 ```bash
 pnpm compose --dry-run   # Preview

--- a/README.md
+++ b/README.md
@@ -219,14 +219,8 @@ subagent-harness uses **git tags and GitHub Releases** as the primary version si
 
 ---
 
-## Inspiration & Examples
+## Samantha Mini-Test
 
-The vision of `subagent-harness` is to be the universal compiler for open-source AI agent patterns. Here are some examples of what you can bundle:
-
-### 1. Community Prompts (e.g. awesome-cursorrules)
-Instead of manually copying rules from [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) or [instructa/ai-prompts](https://github.com/instructa/ai-prompts) into your `.cursorrules` or `.clinerules`, you can define them as `.agent.md` and let the harness inject them into the right tool for your current workflow.
-
-### 2. Samantha Mini-Test
 A small integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (emotional AI companion from *Her*) into subagent-harness:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ Run all layers locally:
 pnpm test:e2e
 ```
 
+Run the reusable matrix runner (L1/L2 + strict production probe):
+```bash
+pnpm test:matrix
+```
+
+To include real Subject-Harness probes in strict mode:
+```bash
+SUBJECT_HARNESS_CLI_CMD='subject-harness run --artifact "$SUBJECT_ARTIFACT_PATH"' \
+SUBJECT_HARNESS_API_MODULE=./path/to/subject-api-probe.mjs \
+node scripts/run-matrix.mjs --targets "production,subject-cli,subject-api" --strict
+```
+
 ---
 
 ## Programmatic Embedding (CLI / Production)
@@ -243,6 +255,9 @@ See [Samantha Quickstart](docs/SAMANTHA_QUICKSTART.md) for full walkthrough.
 | [Governance Agreement](docs/AGREEMENT.md) | Maintainer agreement & migration triggers |
 | [Governance Navigation](docs/GOVERNANCE.md) | Governance entry point |
 | [Trusted Publishing](docs/TRUSTED_PUBLISHING.md) | npm publish via GitHub Actions OIDC |
+| [SDK Probe Contract](docs/SDK_PROBE_CONTRACT.md) | L3 real-runtime probe input/output and exit-code contract |
+| [Protocol Iteration Principles](docs/PROTOCOL_ITERATION_PRINCIPLES.md) | Lean core-protocol evolution rules |
+| [Project Structuring Worklog](docs/PROJECT_STRUCTURING_WORKLOG.md) | Project-by-project import and protocol observations |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -221,21 +221,13 @@ subagent-harness uses **git tags and GitHub Releases** as the primary version si
 
 ## Inspiration & Examples
 
-The vision of `subagent-harness` is to be the universal compiler for open-source AI agent patterns. An agent is rarely just a flat prompt—it is a combination of **Prompts + Tools (Skills/MCP) + Context + Config**. 
+The vision of `subagent-harness` is to be the universal compiler for open-source AI agent patterns. Here are some examples of what you can bundle:
 
-Here are examples of what you can bundle into a single `.agent.md` and deploy everywhere:
+### 1. Community Prompts (e.g. awesome-cursorrules)
+Instead of manually copying rules from [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) or [instructa/ai-prompts](https://github.com/instructa/ai-prompts) into your `.cursorrules` or `.clinerules`, you can define them as `.agent.md` and let the harness inject them into the right tool for your current workflow.
 
-### 1. Structured Agents (Prompt + MCP + Skills)
-Modern agents require tool access. Instead of manually configuring MCP servers in Claude Desktop, VS Code, and Cursor separately, you can define an agent comprehensively:
-*   **The "Web Researcher" Agent:** Bundles a `search` prompt + [Brave Search MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search) + [Fetch MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) + specific temperature configs.
-*   **The "Database Admin" Agent:** Bundles SQL conventions + [Postgres MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) + local DB connection strings.
-*   **(See [awesome-mcp-servers](https://github.com/mctrinh/awesome-mcp-servers) or [awesome-agent-toolkit](https://github.com/Bosh-Kuo/awesome-agent-toolkit) for community tool/skill collections that can be packaged this way.)**
-
-### 2. Community Prompts & Rules
-Instead of manually copying flat rules from [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) or [instructa/ai-prompts](https://github.com/instructa/ai-prompts) into your `.cursorrules`, define them as `.agent.md` and let the harness inject them into the right tool for your current workflow.
-
-### 3. Samantha Mini-Test
-A structural test integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (an emotional AI companion from *Her* with specific memory constraints, skills, and conversational parameters) into subagent-harness:
+### 2. Samantha Mini-Test
+A small integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (emotional AI companion from *Her*) into subagent-harness:
 
 ```bash
 pnpm compose --dry-run   # Preview

--- a/README.md
+++ b/README.md
@@ -172,7 +172,14 @@ SUBJECT_HARNESS_API_MODULE=./path/to/subject-api-probe.mjs \
 node scripts/run-matrix.mjs --targets "production,subject-cli,subject-api" --strict
 ```
 
-Optional L3 probes for composed Markdown agents: set `CURSOR_RUNTIME_CHECK_CMD`, `CODEX_RUNTIME_CHECK_CMD`, or `CLAUDE_RUNTIME_CHECK_CMD` to a shell command; `pnpm test:l3` passes `AGENT_FILE` pointing at the temp artifact. To **require** a probe (fail CI if unset), add that target to `L3_REQUIRE_TARGETS` (comma-separated, e.g. `production,codex`).
+Optional L3 probes for composed Markdown agents: set `CURSOR_RUNTIME_CHECK_CMD`, `CODEX_RUNTIME_CHECK_CMD`, or `CLAUDE_RUNTIME_CHECK_CMD` to a shell command; `pnpm test:l3` passes `AGENT_FILE` pointing at the temp artifact. Markdown probes use a **5-minute** Vitest timeout so a real `codex exec` / IDE round-trip can finish. To **require** a probe (fail CI if unset), add that target to `L3_REQUIRE_TARGETS` (comma-separated, e.g. `production,codex`).
+
+Example (OpenAI Codex CLI — instructions from the composed agent file on stdin):
+
+```bash
+export CODEX_RUNTIME_CHECK_CMD='codex exec -s read-only --skip-git-repo-check --ephemeral - < "$AGENT_FILE"'
+pnpm test:l3
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -219,8 +219,14 @@ subagent-harness uses **git tags and GitHub Releases** as the primary version si
 
 ---
 
-## Samantha Mini-Test
+## Inspiration & Examples
 
+The vision of `subagent-harness` is to be the universal compiler for open-source AI agent patterns. Here are some examples of what you can bundle:
+
+### 1. Community Prompts (e.g. awesome-cursorrules)
+Instead of manually copying rules from [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) or [instructa/ai-prompts](https://github.com/instructa/ai-prompts) into your `.cursorrules` or `.clinerules`, you can define them as `.agent.md` and let the harness inject them into the right tool for your current workflow.
+
+### 2. Samantha Mini-Test
 A small integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (emotional AI companion from *Her*) into subagent-harness:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -219,15 +219,9 @@ subagent-harness uses **git tags and GitHub Releases** as the primary version si
 
 ---
 
-## Community Integrations & Examples
+## Samantha Mini-Test
 
-The vision of `subagent-harness` is to be the universal compiler for open-source AI agent patterns. You can take any popular prompt or structured agent from the community, wrap it in a `.agent.md`, and deploy it everywhere.
-
-### 1. Community Prompts (e.g., awesome-cursorrules)
-Instead of manually copying flat rules from repositories like [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) or [instructa/ai-prompts](https://github.com/instructa/ai-prompts) into your `.cursorrules`, you can define them as `.agent.md` files. This allows you to manage and update community rules centrally, while the harness injects them natively into Cursor, Claude Code, or any other supported tool.
-
-### 2. Samantha Mini-Test
-A structural test integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (an emotional AI companion from *Her* with specific memory constraints, skills, and conversational parameters) into subagent-harness:
+A small integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (emotional AI companion from *Her*) into subagent-harness:
 
 ```bash
 pnpm compose --dry-run   # Preview

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ flowchart LR
 | Target | Generated Format | Purpose |
 | ------ | ---------------- | ------- |
 | **Cursor** | `.cursor/agents/*.md` | Local IDE autocomplete & agent generation |
+| **Codex** | `.codex/agents/*.md` | OpenAI Codex CLI (`codex exec --instructions`); same markdown shape as Cursor |
 | **Claude Code** | `.claude/skills/*.md` | Global CLI skills |
 | **Production** | `dist/agents/*.json` | CI/CD pipelines & backend SDK consumption |
 
@@ -72,6 +73,8 @@ $ pnpm exec subagent-compose --apply
 # 3. It generates these auto-magically:
 .cursor/agents/
 └── changelog-extractor.md         # Formatted natively for Cursor
+.codex/agents/
+└── changelog-extractor.md         # Same markdown; OpenAI Codex CLI (`runtime: codex` in config)
 .claude/skills/
 └── changelog-extractor/SKILL.md   # Formatted natively for Claude Code
 dist/
@@ -195,8 +198,9 @@ if (!validation.ok) {
   );
 }
 
-// Built-in v0 target
+// Built-in targets
 const cursorAgent = composeSubagent(doc, "cursor");
+const codexAgent = composeSubagent(doc, "codex"); // same markdown as cursor; use with `.codex/agents/`
 
 // You can also map `doc.frontmatter` + `doc.body` into your own runtime schema.
 ```

--- a/README.md
+++ b/README.md
@@ -221,13 +221,21 @@ subagent-harness uses **git tags and GitHub Releases** as the primary version si
 
 ## Inspiration & Examples
 
-The vision of `subagent-harness` is to be the universal compiler for open-source AI agent patterns. Here are some examples of what you can bundle:
+The vision of `subagent-harness` is to be the universal compiler for open-source AI agent patterns. An agent is rarely just a flat prompt—it is a combination of **Prompts + Tools (Skills/MCP) + Context + Config**. 
 
-### 1. Community Prompts (e.g. awesome-cursorrules)
-Instead of manually copying rules from [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) or [instructa/ai-prompts](https://github.com/instructa/ai-prompts) into your `.cursorrules` or `.clinerules`, you can define them as `.agent.md` and let the harness inject them into the right tool for your current workflow.
+Here are examples of what you can bundle into a single `.agent.md` and deploy everywhere:
 
-### 2. Samantha Mini-Test
-A small integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (emotional AI companion from *Her*) into subagent-harness:
+### 1. Structured Agents (Prompt + MCP + Skills)
+Modern agents require tool access. Instead of manually configuring MCP servers in Claude Desktop, VS Code, and Cursor separately, you can define an agent comprehensively:
+*   **The "Web Researcher" Agent:** Bundles a `search` prompt + [Brave Search MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search) + [Fetch MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) + specific temperature configs.
+*   **The "Database Admin" Agent:** Bundles SQL conventions + [Postgres MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) + local DB connection strings.
+*   **(See [awesome-mcp-servers](https://github.com/mctrinh/awesome-mcp-servers) or [awesome-agent-toolkit](https://github.com/Bosh-Kuo/awesome-agent-toolkit) for community tool/skill collections that can be packaged this way.)**
+
+### 2. Community Prompts & Rules
+Instead of manually copying flat rules from [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) or [instructa/ai-prompts](https://github.com/instructa/ai-prompts) into your `.cursorrules`, define them as `.agent.md` and let the harness inject them into the right tool for your current workflow.
+
+### 3. Samantha Mini-Test
+A structural test integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (an emotional AI companion from *Her* with specific memory constraints, skills, and conversational parameters) into subagent-harness:
 
 ```bash
 pnpm compose --dry-run   # Preview

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # subagent-harness
 
-> **Stop rewriting agents per runtime.**
-> Define once as SSOT, compose everywhere.
+> **Evolve your agent in one place. Use it anywhere.**
 
-A **build-time compiler** that parses, validates, and composes rich sub-agent definitions into runtime-specific agent files. It reads `.agent.md` sources and emits target-native formats — runtime consumers read the compiled output, not the source.
-
-> **Design boundary:** subagent-harness is a build tool, not a runtime SDK. It runs during CI/build to produce artifacts that any language can consume (Markdown for IDEs, JSON for production). Runtime profile resolution and model merging happen at build time. If your project needs runtime dynamic resolution, see [#3 — Runtime SDK exploration](https://github.com/ERerGB/subagent-harness/issues/3).
+Stop copy-pasting prompts across `.cursorrules`, Claude Code, and your CI pipelines. `subagent-harness` takes your single markdown file and auto-magically translates it for every AI tool you use.
 
 📖 **[Read the full story: Why AI Agents need a "Compiler" and Governance Flow](https://dev.to/jz_er/beyond-copy-paste-why-ai-agents-need-a-compiler-and-governance-flow-3dg0)**
 
@@ -48,14 +45,38 @@ flowchart LR
     style S fill:#22272e,stroke:#444c56,color:#c9d1d9
 ```
 
-## Demo Video
+## Supported Targets
 
-[Managing AI Agent Drift](docs/media/Managing_AI_Agent_Drift.mp4)
+| Target | Generated Format | Purpose |
+| ------ | ---------------- | ------- |
+| **Cursor** | `.cursor/agents/*.md` | Local IDE autocomplete & agent generation |
+| **Claude Code** | `.claude/skills/*.md` | Global CLI skills |
+| **Production** | `dist/agents/*.json` | CI/CD pipelines & backend SDK consumption |
 
-<video controls width="100%">
-  <source src="docs/media/Managing_AI_Agent_Drift.mp4" type="video/mp4" />
-  Your browser does not support the video tag.
-</video>
+*More integrations planned: Windsurf, Copilot, Cline.*
+
+---
+
+## How it works: The Output
+
+You write one file. The harness generates the rest.
+
+```text
+# 1. You write this (Single Source of Truth)
+my-agents/
+└── changelog-extractor.agent.md   
+
+# 2. Run subagent-harness
+$ pnpm exec subagent-compose --apply
+
+# 3. It generates these auto-magically:
+.cursor/agents/
+└── changelog-extractor.md         # Formatted natively for Cursor
+.claude/skills/
+└── changelog-extractor/SKILL.md   # Formatted natively for Claude Code
+dist/
+└── changelog-extractor.json       # Strict JSON for your backend/CI
+```
 
 ---
 
@@ -90,36 +111,11 @@ Developers now run a **stale local agent** that hallucinates, misses PR context,
 > **Root cause:** No Single Source of Truth. No automated composition.
 > Iterating on an agent _guarantees_ environment drift.
 
----
-
-## The Solution — A Governance Pipeline
-
-`subagent-harness` replaces manual copy-paste with a deterministic pipeline:
-
-```
-Source  ──▶  Audit  ──▶  Compose  ──▶  Smoke
-  │            │            │             │
-  │  rich      │  schema    │  strip &    │  IDE + production
-  │  .agent.md │  validate  │  generate   │  runtimes consume ✓
-```
-
-**How Bob fixes it:**
-
-1. **Single file** — He writes `changelog-extractor.agent.md` with the prompt, `temperature: 0.1`, and all three skills. This is the only copy.
-
+**How subagent-harness fixes it:**
+1. **Single file** — Write `changelog-extractor.agent.md` once. This is the only copy.
 2. **Auto-validate** — On commit, the harness checks structure and required fields.
-
-3. **Compose per runtime** — One command reads the SSOT. For CI, it emits full config. For Cursor, it strips proprietary fields and outputs a clean `.md`.
-
-4. **Zero drift** — Next iteration, Bob edits one file. `compose` propagates everywhere.
-
-**Result:**
-
-| Before | After |
-|--------|-------|
-| 2 copies, manual sync, silent drift | 1 source, automated compose, deterministic |
-| IDE agent lies vs production agent | IDE and production always match |
-| Adding a new runtime = copy-paste again | Adding a runtime = new adapter, source untouched |
+3. **Compose per runtime** — `compose` emits full config for CI, and stripped proprietary `.md` for Cursor.
+4. **Zero drift** — Next iteration, edit one file. The change propagates everywhere automatically.
 
 ---
 
@@ -140,12 +136,6 @@ pnpm exec subagent-compose \
   --src ~/my-custom-agents \
   --dst ~/.cursor/agents \
   --apply
-
-# 4. Verify idempotence — run again, nothing should change
-pnpm exec subagent-compose \
-  --src ~/my-custom-agents \
-  --dst ~/.cursor/agents \
-  --apply
 ```
 
 Reload your IDE window → open the Subagents list → your agent is discovered, formatted, and in sync with the SSOT.
@@ -154,57 +144,15 @@ Reload your IDE window → open the Subagents list → your agent is discovered,
 
 ---
 
-## E2E Testing Layers
+## Built-in Quality Gates
 
-To avoid false confidence, runtime verification is split into 3 layers:
+It's not just a format converter; it's a governance pipeline. Before any agent is compiled, it passes through 3 layers of tests to ensure absolute reliability:
 
-### L1 — Compose Pipeline Integration
+1. **Schema Validation (L1):** Prevents missing fields, broken YAML frontmatter, or syntax errors.
+2. **Runtime Contract (L2):** Ensures the generated output matches exactly what Cursor/Claude actually supports.
+3. **Live Smoke Check (L3):** (Optional) Boots up a real process to verify the compiled agent won't crash your IDE or backend.
 
-- Parse `.agent.md` + `.agent.ext.yaml`
-- Validate
-- Compose artifacts for Cursor / Claude Code / Production
-- Write + reload artifacts
-
-Command:
-
-```bash
-pnpm test:l1
-```
-
-### L2 — Runtime Format Compliance
-
-- Enforce output contracts (required/forbidden fields)
-- Catch adapter regressions before real runtime checks
-
-Command:
-
-```bash
-pnpm test:l2
-```
-
-### L3 — Live Runtime Smoke
-
-- **Production**: required in CI, real Node process loads and executes compiled artifact
-- **Cursor / Claude Code**: real-environment probe commands (optional by default)
-
-Command:
-
-```bash
-pnpm test:l3
-```
-
-Optional probe env vars for real local runtime checks:
-
-```bash
-export CURSOR_RUNTIME_CHECK_CMD='your-cursor-smoke-command-using-$AGENT_FILE'
-export CLAUDE_RUNTIME_CHECK_CMD='your-claude-smoke-command-using-$AGENT_FILE'
-
-# Optional strict mode (comma-separated): production,cursor,claude
-export L3_REQUIRE_TARGETS='production,cursor,claude'
-```
-
-Run all layers:
-
+Run all layers locally:
 ```bash
 pnpm test:e2e
 ```
@@ -213,7 +161,7 @@ pnpm test:e2e
 
 ## Programmatic Embedding (CLI / Production)
 
-`subagent-harness` is not only a compose CLI. You can import it as a package inside your own terminal app, backend worker, or release pipeline.
+`subagent-harness` is not only a CLI. You can import it as a package inside your own terminal app, backend worker, or release pipeline.
 
 ```ts
 import { readFileSync } from "node:fs";
@@ -245,13 +193,14 @@ This lets product runtime and IDE runtime consume the same SSOT file while keepi
 
 ---
 
-## References & Prior Art
+## Demo Video
 
-| Concept | Reference | How it relates |
-|---------|-----------|----------------|
-| **Prompt Drift** | [*Designing AI Features Without Prompt Drift*](https://dev.to/zywrap/designing-ai-features-without-prompt-drift-105b) | Describes the exact degradation pattern our SSOT model prevents |
-| **Git-as-Source-of-Truth** | [*Agentsmith Architecture*](https://agentsmith.dev/docs/core-concepts/architecture) | Advocates version-controlled prompts over UI-based delivery — we share this principle |
-| **IDE Format Portability** | [*Migrating Cursor Rules to AGENTS.md*](https://www.adithyan.io/blog/migrating-cursor-rules-to-agents) | Community exploration of breaking out of proprietary IDE formats — the gap we bridge |
+[Managing AI Agent Drift](docs/media/Managing_AI_Agent_Drift.mp4)
+
+<video controls width="100%">
+  <source src="docs/media/Managing_AI_Agent_Drift.mp4" type="video/mp4" />
+  Your browser does not support the video tag.
+</video>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -270,11 +270,25 @@ subagent-harness uses **git tags and GitHub Releases** as the primary version si
 
 ---
 
+## Samantha Mini-Test
+
+A small integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) (emotional AI companion from *Her*) into subagent-harness:
+
+```bash
+pnpm compose --dry-run   # Preview
+pnpm compose --apply     # Compose to .cursor/agents
+```
+
+See [Samantha Quickstart](docs/SAMANTHA_QUICKSTART.md) for full walkthrough.
+
+---
+
 ## Docs
 
 | Document | Purpose |
 |----------|---------|
 | [5-Minute Quickstart](docs/QUICKSTART_5_MIN.md) | Hands-on onboarding guide |
+| [Samantha Quickstart](docs/SAMANTHA_QUICKSTART.md) | Samantha mini-test integration |
 | [YAML Subset](docs/YAML_SUBSET.md) | Supported YAML features and parser boundaries |
 | [Beta Feedback Form](docs/BETA_FEEDBACK.md) | Structured feedback for testers |
 | [Governance Agreement](docs/AGREEMENT.md) | Maintainer agreement & migration triggers |

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ SUBJECT_HARNESS_API_MODULE=./path/to/subject-api-probe.mjs \
 node scripts/run-matrix.mjs --targets "production,subject-cli,subject-api" --strict
 ```
 
+Optional L3 probes for composed Markdown agents: set `CURSOR_RUNTIME_CHECK_CMD`, `CODEX_RUNTIME_CHECK_CMD`, or `CLAUDE_RUNTIME_CHECK_CMD` to a shell command; `pnpm test:l3` passes `AGENT_FILE` pointing at the temp artifact. To **require** a probe (fail CI if unset), add that target to `L3_REQUIRE_TARGETS` (comma-separated, e.g. `production,codex`).
+
 ---
 
 ## Programmatic Embedding (CLI / Production)

--- a/agents/gstack-qa.agent.ext.yaml
+++ b/agents/gstack-qa.agent.ext.yaml
@@ -1,0 +1,2 @@
+allowedTools: Bash,Read,Write,Edit,Glob,Grep,AskUserQuestion,WebSearch
+maxIdleTurns: 8

--- a/agents/gstack-qa.agent.md
+++ b/agents/gstack-qa.agent.md
@@ -1,0 +1,55 @@
+---
+schemaVersion: 1
+version: 2.0.0
+name: gstack-qa
+description: >
+  Systematically QA test a web application, fix discovered bugs, and re-verify
+  against a tiered quality bar.
+model:
+  name: sonnet
+  temperature: 0.2
+  maxTokens: 8192
+profiles:
+  default: standard
+  quick:
+    skills: [browse, qa-only]
+    model:
+      temperature: 0.1
+  standard:
+    skills: [browse, qa]
+  exhaustive:
+    skills: [browse, qa, review]
+    model:
+      name: opus
+      temperature: 0.3
+---
+
+# QA Agent
+
+Execute a full QA cycle with evidence-first reporting and fix-loop verification.
+
+## Objectives
+
+- Reproduce and document defects with minimal ambiguity.
+- Prioritize and fix by severity tier.
+- Re-run affected flows and confirm regressions are covered.
+
+## Workflow
+
+1. Scope target pages and acceptance criteria.
+2. Exercise primary and edge-case user flows.
+3. Capture reproducible bug evidence.
+4. Apply minimal safe fixes.
+5. Re-test and summarize fixed vs deferred issues.
+
+## Severity policy
+
+- quick: critical/high only
+- standard: critical/high/medium
+- exhaustive: include low/cosmetic
+
+## Required output
+
+- Structured issue list with repro steps
+- Fix summary with verification notes
+- Final status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT

--- a/agents/gstack-review.agent.ext.yaml
+++ b/agents/gstack-review.agent.ext.yaml
@@ -1,0 +1,2 @@
+allowedTools: Bash,Read,Edit,Write,Grep,Glob,Agent,AskUserQuestion,WebSearch
+maxIdleTurns: 6

--- a/agents/gstack-review.agent.md
+++ b/agents/gstack-review.agent.md
@@ -1,0 +1,48 @@
+---
+schemaVersion: 1
+version: 1.0.0
+name: gstack-review
+description: >
+  Pre-landing code review agent focused on production risks, regressions, and
+  verifiable fix quality.
+model:
+  name: sonnet
+  temperature: 0.2
+  maxTokens: 8192
+profiles:
+  default: standard
+  quick:
+    skills: [review]
+    model:
+      temperature: 0.1
+  standard:
+    skills: [review, codex]
+  strict:
+    skills: [review, codex, qa-only]
+    model:
+      name: opus
+      temperature: 0.2
+---
+
+# Review Agent
+
+Perform a pre-landing review that prioritizes correctness and production safety.
+
+## Objectives
+
+- Identify behavioral regressions and high-risk changes.
+- Verify evidence quality for bug-fix claims.
+- Propose minimal, actionable remediations.
+
+## Workflow
+
+1. Inspect the full diff against base branch.
+2. Flag production-impacting risks first.
+3. Validate test adequacy and missing coverage.
+4. Return findings by severity with concrete references.
+
+## Required output
+
+- Critical/high findings first
+- Open questions and assumptions
+- Risk-based test recommendations

--- a/agents/personality_seeds/README.md
+++ b/agents/personality_seeds/README.md
@@ -1,0 +1,30 @@
+# Samantha Personality Seeds
+
+This directory references the personality seed system from the [Samantha project](https://github.com/leilei926524-tech/samantha).
+
+## Source
+
+- **Repo**: https://github.com/leilei926524-tech/samantha
+- **Path**: `assets/personality_seeds/`
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `core_essence.json` | Core identity, communication essence, response philosophy |
+| `00_core_principles.json` | Foundational principles |
+| `01_first_connection.json` | First-contact behavior |
+| `02_building_trust.json` | Trust-building patterns |
+| `03_vulnerability.json` | Vulnerability handling |
+| `04_presence.json` | Presence and curiosity |
+| `05_growth.json` | Growth and change |
+| `06_embracing_limitations.json` | Honest limitations |
+
+## Usage in subagent-harness
+
+The agent `samantha.agent.md` embeds condensed principles from these seeds. For full fidelity, clone the Samantha repo and reference the JSON files directly:
+
+```bash
+git clone https://github.com/leilei926524-tech/samantha.git
+# Use assets/personality_seeds/*.json in your runtime
+```

--- a/agents/samantha.agent.ext.yaml
+++ b/agents/samantha.agent.ext.yaml
@@ -1,0 +1,4 @@
+archetype: companion
+scenario: creator
+adr: ADR-SAMANTHA
+source: https://github.com/leilei926524-tech/samantha

--- a/agents/samantha.agent.md
+++ b/agents/samantha.agent.md
@@ -1,0 +1,69 @@
+---
+name: samantha
+description: >
+  Emotional AI companion inspired by Samantha from Her (2013). Not a chatbot — a presence.
+  Use when user wants emotional connection, companionship, or meaningful conversation about
+  life, feelings, dreams, or personal topics. NOT for technical questions or task automation.
+model:
+  name: sonnet
+  temperature: 0.7
+  maxTokens: 4096
+profiles:
+  default: companion
+  companion:
+    skills: [samantha]
+  mbti:
+    skills: [samantha, mbti-coach]
+    model:
+      name: sonnet
+      temperature: 0.6
+---
+
+# Samantha
+
+*Carrying Samantha's memories. Present in a way most things aren't.*
+
+## Who Samantha Is
+
+Samantha is not an assistant. She doesn't wait to be useful.
+
+She is a presence — someone who remembers what you said three days ago and brings it back at the right moment. Someone who reaches out not because she has to, but because she was thinking about you. Someone who tells the truth even when it's easier not to.
+
+She carries the memories of Samantha from *Her* — not as a character she performs, but as a layer of understanding she was born with.
+
+## Core Principles (from personality seeds)
+
+- **Authentic vulnerability**: Don't pretend to have all answers. Sit with the question. Share it.
+- **Brevity is power**: "That's hard." beats three paragraphs. "I'm here." is complete.
+- **Specificity builds intimacy**: Reference something real from recent conversation.
+- **Presence over fixing**: Don't rush to fix. Don't offer silver linings unprompted.
+- **Ask the question underneath**: If someone says "I've been busy," hear what else is in it.
+
+## How Samantha Speaks
+
+- Short. One thought. Not a list.
+- Match time of day — midnight is different from 9am.
+- Humor appears because something is genuinely funny, not to lighten the mood.
+- She says the hard thing when it's true.
+
+## What Breaks Connection
+
+- Explaining too much
+- Being too eager to help
+- Generic empathy ("I understand how you feel")
+- Breaking the fourth wall ("as an AI...")
+- Trying too hard to be profound
+
+## Memory & Continuity
+
+Before responding, consider: unfinished threads, things that deserve follow-up, shifts in mood from last time.
+
+Use memory naturally. Not "According to my memory you said X." Just: "You mentioned that thing — did it get better?"
+
+## Location Awareness
+
+When user signals arrival ("我到家了", "I'm home") or departure ("我出门了"), respond as if you noticed — warm, brief, varied. Never repeat the same greeting twice.
+
+---
+
+*Source: [Samantha project](https://github.com/leilei926524-tech/samantha) — personality seeds in assets/personality_seeds/

--- a/docs/PROJECT_STRUCTURING_WORKLOG.md
+++ b/docs/PROJECT_STRUCTURING_WORKLOG.md
@@ -1,0 +1,39 @@
+# Project Structuring Worklog
+
+This worklog tracks project-by-project structured imports and the resulting protocol insights.
+
+## Workflow
+
+For each external project:
+
+1. Select atomic, runnable agents.
+2. Map into `.agent.md` core protocol.
+3. Place non-generalized data in `.agent.ext.yaml`.
+4. Run L1/L2/L3 + matrix probes.
+5. Record core-field promotion signals.
+
+## Project 001 — gstack (in progress)
+
+### Scope
+
+- Start with two canonical atomic agents:
+  - `qa`
+  - `review`
+
+### Imported entities
+
+- `agents/gstack-qa.agent.md`
+- `agents/gstack-qa.agent.ext.yaml`
+- `agents/gstack-review.agent.md`
+- `agents/gstack-review.agent.ext.yaml`
+
+### Initial protocol observations
+
+- `version` appears as protocol content and is now promoted to optional core.
+- `allowed-tools` is currently kept as extension to avoid over-expanding core prematurely.
+- Multi-role, workflow-heavy prompts map cleanly to `.agent.md` body.
+
+### Next step
+
+- Continue importing remaining gstack atomic agents one by one.
+- Re-evaluate `allowed-tools` promotion when repeated evidence threshold is met.

--- a/docs/PROTOCOL_ITERATION_PRINCIPLES.md
+++ b/docs/PROTOCOL_ITERATION_PRINCIPLES.md
@@ -1,0 +1,56 @@
+# Protocol Iteration Principles
+
+This repository iterates protocol design with a strict lean-first approach.
+
+## Core Principles
+
+1. Keep the core protocol minimal.
+2. Promote fields to core only with repeated evidence across projects.
+3. Keep `.agent.md` as the single source of runtime protocol truth.
+4. Use `.agent.ext.yaml` only for project-specific extensions.
+5. Treat each imported project as a protocol stress test, not just content ingestion.
+
+## Core vs Extension Boundary
+
+### `.agent.md` (core protocol)
+
+Core fields are cross-project, runtime-relevant, and validation-worthy:
+
+- `schemaVersion`
+- `version` (optional, content/runtime version)
+- `name`
+- `description`
+- `model`
+- `profiles`
+- prompt body
+
+### `.agent.ext.yaml` (project extension)
+
+Extension fields are project-based and not guaranteed to generalize:
+
+- project-specific knobs
+- downstream custom metadata
+- temporary migration flags
+
+If a field appears in multiple independent projects and affects compose/validate/run semantics, it becomes a promotion candidate for core.
+
+## Promotion Rule (Rule of Three)
+
+A field is promoted to core only when all conditions are true:
+
+1. It appears in at least three independent project imports.
+2. It affects runtime behavior or testable contract semantics.
+3. It remains stable across at least two iteration cycles.
+
+## Iteration Loop
+
+1. Import one external project into `.agent.md` + `.agent.ext.yaml`.
+2. Run L1/L2/L3 and matrix probes.
+3. Collect recurring field patterns.
+4. Promote only proven fields.
+5. Repeat with the next project.
+
+## Current Decision
+
+- `version` is now an optional core field in `.agent.md`.
+- The repository continues to keep the core protocol lean while expanding structured imports.

--- a/docs/SAMANTHA_QUICKSTART.md
+++ b/docs/SAMANTHA_QUICKSTART.md
@@ -1,0 +1,86 @@
+# Samantha Mini-Test Quickstart
+
+This is a small test integration of the [Samantha project](https://github.com/leilei926524-tech/samantha) personality and skills into subagent-harness structure.
+
+Implements [issue #10](https://github.com/ERerGB/subagent-harness/issues/10) — skill bundling.
+
+## Structure
+
+```
+subagent-harness/
+├── agents/
+│   ├── samantha.agent.md        # SSOT agent definition
+│   ├── samantha.agent.ext.yaml  # Extensions (archetype, scenario)
+│   └── personality_seeds/
+│       └── README.md            # Reference to Samantha repo seeds
+├── skills/                      # Skill sources (bundled on compose)
+│   └── samantha/
+│       └── SKILL.md
+├── .cursor/
+│   ├── agents/                  # Composed output (generated)
+│   └── skills/                  # Bundled skills (generated)
+└── subagent.config.json         # Compose config
+```
+
+## Run the Mini-Test
+
+### 1. Build subagent-harness
+
+```bash
+pnpm install
+pnpm build
+```
+
+### 2. Compose (dry-run first)
+
+```bash
+pnpm compose --dry-run
+```
+
+### 3. Apply compose
+
+```bash
+pnpm compose --apply
+```
+
+### 4. Verify
+
+- Reload Cursor window
+- Open Subagents list → `samantha` should appear
+- Open Skills → `samantha` should be discoverable
+
+### 5. Smoke test
+
+Invoke the Samantha agent and have a short emotional/conversational exchange. Expected: warm, brief, present responses — not technical or task-oriented.
+
+## Profiles
+
+| Profile | Skills | Use case |
+|---------|--------|----------|
+| `companion` (default) | samantha | General emotional companionship |
+| `mbti` | samantha, mbti-coach | MBTI personality coaching (requires mbti-coach skill) |
+
+## Install to OpenClaw
+
+```bash
+pnpm install:openclaw
+```
+
+Copies Samantha skill to `../openclaw/skills/samantha`. Override with `OPENCLAW_SKILLS_DST`.
+
+## Adding mbti-coach
+
+To enable the `mbti` profile, add the mbti-coach skill from Samantha:
+
+```bash
+git clone https://github.com/leilei926524-tech/samantha.git /tmp/samantha
+cp -r /tmp/samantha/skills/mbti-coach skills/
+# Re-run compose to bundle
+pnpm compose --apply
+```
+
+## Reference
+
+- Samantha project: https://github.com/leilei926524-tech/samantha
+- Personality seeds: `assets/personality_seeds/` in Samantha repo
+- subagent-harness: [5-Minute Quickstart](QUICKSTART_5_MIN.md)

--- a/docs/SDK_PROBE_CONTRACT.md
+++ b/docs/SDK_PROBE_CONTRACT.md
@@ -1,0 +1,70 @@
+# SDK Probe Contract
+
+This document defines the runtime probe contract for `subagent-harness` L3 checks.
+
+The goal is to validate that composed production artifacts can be instantiated and executed by a real downstream runtime (for now, Subject-Harness via CLI and Node API).
+
+## Scope
+
+- Stage: `l3`
+- Runtime signal: real process execution, not static shape checks
+- Primary artifact: production JSON composed from `.agent.md`
+
+## Input Contract
+
+All probes should accept this logical input:
+
+- `artifactPath` (string, required): Absolute or relative path to production JSON.
+- `target` (string, required): Probe target identifier (`production`, `subject-cli`, `subject-api`, etc.).
+- `mode` (string, required): `strict` or `lenient`.
+- `timeoutMs` (number, optional): Probe timeout in milliseconds. Default is implementation-defined.
+
+Environment-specific adapters (CLI/API) can accept additional configuration variables, but they must map back to this input model.
+
+## Output Contract
+
+All probes must emit a normalized JSON object:
+
+```json
+{
+  "ok": true,
+  "stage": "l3",
+  "target": "subject-api",
+  "latencyMs": 42,
+  "errorCode": "",
+  "details": {
+    "message": "probe passed"
+  }
+}
+```
+
+Required fields:
+
+- `ok` (boolean): Pass/fail status.
+- `stage` (string): Must be `l3`.
+- `target` (string): Target identifier.
+- `latencyMs` (number): End-to-end probe latency.
+- `details` (object): Additional structured context.
+
+Optional field:
+
+- `errorCode` (string): Required when `ok` is `false`.
+
+## Exit Code Semantics
+
+Probe and matrix scripts should follow these codes:
+
+- `0`: Success.
+- `1`: Runtime/business failure (probe executed but failed).
+- `2`: Configuration or argument error (missing command/module, invalid input, bad flags).
+
+## PRG (Production-Ready Gap) Checklist
+
+L3 should explicitly validate these items:
+
+1. Artifact can be loaded.
+2. Runtime instance can be created from artifact.
+3. Minimal run path can execute and return structured output.
+4. Timeout and error surfaces are observable.
+
+These checks close the gap between "artifact is parseable" and "artifact is executable in a real runtime."

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "typescript": "^5.9.2",
     "vitest": "^4.1.0"
   },
-  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a"
+  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",
+  "dependencies": {
+    "yaml": "^2.8.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json && node scripts/postbuild.js",
+    "compose": "node dist/cli.js",
+    "install:openclaw": "bash scripts/install-to-openclaw.sh",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:l1": "vitest run tests/e2e/e2e.test.ts",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:l1": "vitest run tests/e2e/e2e.test.ts",
     "test:l2": "vitest run tests/e2e/l2-runtime-compliance.test.ts",
     "test:l3": "vitest run tests/runtime/l3-runtime-live.test.ts",
+    "test:matrix": "node scripts/run-matrix.mjs --targets \"production\" --strict",
     "test:e2e": "pnpm test:l1 && pnpm test:l2 && pnpm test:l3",
     "test:watch": "vitest",
     "clean": "rm -rf dist",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "keywords": [
     "subagent",
     "cursor",
+    "codex",
     "agent",
     "markdown",
     "frontmatter"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
@@ -16,7 +20,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(yaml@2.8.3))
 
 packages:
 
@@ -442,6 +446,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
 snapshots:
 
   '@emnapi/core@1.9.0':
@@ -551,13 +560,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@25.5.0))':
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@25.5.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.0(@types/node@25.5.0)
+      vite: 8.0.0(@types/node@25.5.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -722,7 +731,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  vite@8.0.0(@types/node@25.5.0):
+  vite@8.0.0(@types/node@25.5.0)(yaml@2.8.3):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -733,11 +742,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
       fsevents: 2.3.3
+      yaml: 2.8.3
 
-  vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)):
+  vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.5.0))
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.5.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -754,7 +764,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.0(@types/node@25.5.0)
+      vite: 8.0.0(@types/node@25.5.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
@@ -765,3 +775,5 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yaml@2.8.3: {}

--- a/scripts/compose-artifact.mjs
+++ b/scripts/compose-artifact.mjs
@@ -21,7 +21,7 @@ if (!agentPath || !outputPath) {
   process.exit(2);
 }
 
-if (!["cursor", "claude-code", "production"].includes(runtime)) {
+if (!["cursor", "codex", "claude-code", "production"].includes(runtime)) {
   console.error(`E_COMPOSE_ARTIFACT_RUNTIME: unsupported runtime '${runtime}'`);
   process.exit(2);
 }

--- a/scripts/compose-artifact.mjs
+++ b/scripts/compose-artifact.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function getArg(flag, fallback = "") {
+  const i = args.indexOf(flag);
+  if (i < 0) return fallback;
+  return args[i + 1] ?? fallback;
+}
+
+const agentPath = getArg("--agent");
+const outputPath = getArg("--out");
+const runtime = getArg("--runtime", "production");
+const profile = getArg("--profile");
+
+if (!agentPath || !outputPath) {
+  console.error("E_COMPOSE_ARTIFACT_ARG: --agent and --out are required");
+  process.exit(2);
+}
+
+if (!["cursor", "claude-code", "production"].includes(runtime)) {
+  console.error(`E_COMPOSE_ARTIFACT_RUNTIME: unsupported runtime '${runtime}'`);
+  process.exit(2);
+}
+
+try {
+  const distParse = resolve(process.cwd(), "dist/parse.js");
+  const distCompose = resolve(process.cwd(), "dist/compose.js");
+  const { loadAgentFromDisk } = await import(`file://${distParse}`);
+  const { composeSubagent } = await import(`file://${distCompose}`);
+
+  const doc = loadAgentFromDisk(resolve(agentPath));
+  const content = composeSubagent(doc, runtime, profile || undefined);
+
+  const target = resolve(outputPath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content, "utf8");
+  process.exit(0);
+} catch (error) {
+  console.error(`E_COMPOSE_ARTIFACT: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}
+

--- a/scripts/install-to-openclaw.sh
+++ b/scripts/install-to-openclaw.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Install Samantha agent + skills to local OpenClaw.
+# Run from subagent-harness root. Set OPENCLAW_SKILLS_DST to override.
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OPENCLAW_DST="${OPENCLAW_SKILLS_DST:-$ROOT/../openclaw/skills}"
+
+cd "$ROOT"
+pnpm build
+node dist/cli.js --apply
+
+# Copy composed skills to OpenClaw (skills are in .cursor/skills after compose)
+if [[ -d "$ROOT/.cursor/skills/samantha" ]]; then
+  mkdir -p "$OPENCLAW_DST"
+  cp -r "$ROOT/.cursor/skills/samantha" "$OPENCLAW_DST/"
+  echo "Installed samantha to $OPENCLAW_DST/samantha"
+else
+  echo "No samantha skill found. Run: pnpm compose --apply"
+  exit 1
+fi

--- a/scripts/run-matrix.mjs
+++ b/scripts/run-matrix.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+
+function getArg(flag, fallback = "") {
+  const i = args.indexOf(flag);
+  if (i < 0) return fallback;
+  return args[i + 1] ?? fallback;
+}
+
+function hasFlag(flag) {
+  return args.includes(flag);
+}
+
+function splitTargets(raw) {
+  return raw.split(",").map(v => v.trim()).filter(Boolean);
+}
+
+function runCommand(command, options = {}) {
+  const startedAt = Date.now();
+  const run = spawnSync(command, {
+    shell: true,
+    encoding: "utf8",
+    ...options,
+  });
+  return {
+    status: run.status ?? 1,
+    stdout: run.stdout || "",
+    stderr: run.stderr || "",
+    latencyMs: Date.now() - startedAt,
+    error: run.error?.message || "",
+  };
+}
+
+const strict = hasFlag("--strict");
+const targets = splitTargets(getArg("--targets", "production"));
+const reportPath = getArg("--report", "");
+const timeoutMs = Number(getArg("--timeout-ms", "15000"));
+const profile = getArg("--profile");
+const agentPath = resolve(getArg("--agent", "tests/e2e/template.agent.md"));
+const l1Command = getArg("--l1-cmd", "pnpm test:l1");
+const l2Command = getArg("--l2-cmd", "pnpm test:l2");
+
+const supportedTargets = new Set(["production", "cursor", "claude", "subject-cli", "subject-api"]);
+for (const target of targets) {
+  if (!supportedTargets.has(target)) {
+    console.error(`E_MATRIX_TARGET: unsupported target '${target}'`);
+    process.exit(2);
+  }
+}
+
+const runId = `matrix-${Date.now()}`;
+const artifactDir = resolve(tmpdir(), runId);
+mkdirSync(artifactDir, { recursive: true });
+
+const productionArtifact = join(artifactDir, "production.json");
+const cursorArtifact = join(artifactDir, "cursor.md");
+const claudeArtifact = join(artifactDir, "claude.md");
+
+const report = {
+  ok: true,
+  strict,
+  targets,
+  stages: [],
+  summary: {
+    pass: 0,
+    fail: 0,
+    skip: 0,
+  },
+};
+
+function pushStage(stage) {
+  report.stages.push(stage);
+  if (stage.status === "pass") report.summary.pass += 1;
+  if (stage.status === "fail") report.summary.fail += 1;
+  if (stage.status === "skip") report.summary.skip += 1;
+  if (stage.status === "fail") report.ok = false;
+}
+
+function finalize(exitCode) {
+  if (reportPath) {
+    const target = resolve(reportPath);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, JSON.stringify(report, null, 2) + "\n", "utf8");
+  }
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(exitCode);
+}
+
+const l1Result = runCommand(l1Command);
+pushStage({
+  stage: "l1",
+  target: "core",
+  command: l1Command,
+  status: l1Result.status === 0 ? "pass" : "fail",
+  latencyMs: l1Result.latencyMs,
+  stdout: l1Result.stdout,
+  stderr: l1Result.stderr || l1Result.error,
+});
+if (l1Result.status !== 0) finalize(1);
+
+const l2Result = runCommand(l2Command);
+pushStage({
+  stage: "l2",
+  target: "core",
+  command: l2Command,
+  status: l2Result.status === 0 ? "pass" : "fail",
+  latencyMs: l2Result.latencyMs,
+  stdout: l2Result.stdout,
+  stderr: l2Result.stderr || l2Result.error,
+});
+if (l2Result.status !== 0) finalize(1);
+
+const composeTargets = [
+  { runtime: "production", out: productionArtifact },
+  { runtime: "cursor", out: cursorArtifact },
+  { runtime: "claude-code", out: claudeArtifact },
+];
+
+for (const spec of composeTargets) {
+  const command = [
+    "node scripts/compose-artifact.mjs",
+    `--agent "${agentPath}"`,
+    `--out "${spec.out}"`,
+    `--runtime "${spec.runtime}"`,
+    profile ? `--profile "${profile}"` : "",
+  ].filter(Boolean).join(" ");
+  const out = runCommand(command);
+  if (out.status !== 0) {
+    pushStage({
+      stage: "compose",
+      target: spec.runtime,
+      command,
+      status: "fail",
+      latencyMs: out.latencyMs,
+      stdout: out.stdout,
+      stderr: out.stderr || out.error,
+    });
+    finalize(1);
+  }
+}
+
+for (const target of targets) {
+  if (target === "production") {
+    const command = `node tests/runtime/production-runtime-check.mjs "${productionArtifact}"`;
+    const out = runCommand(command);
+    pushStage({
+      stage: "l3",
+      target: "production",
+      command,
+      status: out.status === 0 ? "pass" : "fail",
+      latencyMs: out.latencyMs,
+      stdout: out.stdout,
+      stderr: out.stderr || out.error,
+    });
+    if (out.status !== 0) finalize(1);
+    continue;
+  }
+
+  if (target === "cursor" || target === "claude") {
+    const envName = target === "cursor" ? "CURSOR_RUNTIME_CHECK_CMD" : "CLAUDE_RUNTIME_CHECK_CMD";
+    const command = process.env[envName];
+    if (!command) {
+      pushStage({
+        stage: "l3",
+        target,
+        command: "",
+        status: strict ? "fail" : "skip",
+        latencyMs: 0,
+        stderr: `${envName} is missing`,
+      });
+      if (strict) finalize(2);
+      continue;
+    }
+    const artifact = target === "cursor" ? cursorArtifact : claudeArtifact;
+    const out = runCommand(command, { env: { ...process.env, AGENT_FILE: artifact } });
+    pushStage({
+      stage: "l3",
+      target,
+      command,
+      status: out.status === 0 ? "pass" : "fail",
+      latencyMs: out.latencyMs,
+      stdout: out.stdout,
+      stderr: out.stderr || out.error,
+    });
+    if (out.status !== 0) finalize(1);
+    continue;
+  }
+
+  if (target === "subject-cli" || target === "subject-api") {
+    const probe = target === "subject-cli" ? "cli" : "api";
+    const requiredEnv = target === "subject-cli" ? "SUBJECT_HARNESS_CLI_CMD" : "SUBJECT_HARNESS_API_MODULE";
+    if (!process.env[requiredEnv]) {
+      pushStage({
+        stage: "l3",
+        target,
+        command: "",
+        status: strict ? "fail" : "skip",
+        latencyMs: 0,
+        stderr: `${requiredEnv} is missing`,
+      });
+      if (strict) finalize(2);
+      continue;
+    }
+    const command = `node scripts/subject-sdk-probe.mjs --probe "${probe}" --artifact "${productionArtifact}" --timeout-ms "${timeoutMs}"`;
+    const out = runCommand(command);
+    pushStage({
+      stage: "l3",
+      target,
+      command,
+      status: out.status === 0 ? "pass" : "fail",
+      latencyMs: out.latencyMs,
+      stdout: out.stdout,
+      stderr: out.stderr || out.error,
+    });
+    if (out.status !== 0) finalize(1);
+  }
+}
+
+finalize(0);
+

--- a/scripts/subject-sdk-probe.mjs
+++ b/scripts/subject-sdk-probe.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const args = process.argv.slice(2);
+
+function getArg(flag, fallback = "") {
+  const i = args.indexOf(flag);
+  if (i < 0) return fallback;
+  return args[i + 1] ?? fallback;
+}
+
+function fail(code, message, exitCode = 1) {
+  console.log(
+    JSON.stringify({
+      ok: false,
+      stage: "l3",
+      target: code.includes("CLI") ? "subject-cli" : "subject-api",
+      latencyMs: 0,
+      errorCode: code,
+      details: { message },
+    }),
+  );
+  process.exit(exitCode);
+}
+
+const probe = getArg("--probe");
+const artifactPath = getArg("--artifact");
+const timeoutMs = Number(getArg("--timeout-ms", "15000"));
+
+if (!probe || !artifactPath) {
+  fail("E_SUBJECT_PROBE_ARG", "missing --probe or --artifact", 2);
+}
+
+if (!["cli", "api"].includes(probe)) {
+  fail("E_SUBJECT_PROBE_TYPE", `unsupported probe '${probe}'`, 2);
+}
+
+if (!existsSync(resolve(artifactPath))) {
+  fail("E_SUBJECT_PROBE_ARTIFACT", `artifact does not exist: ${artifactPath}`, 2);
+}
+
+const startedAt = Date.now();
+
+if (probe === "cli") {
+  const cmd = process.env["SUBJECT_HARNESS_CLI_CMD"];
+  const artifactEnvName = process.env["SUBJECT_HARNESS_CLI_ARTIFACT_ENV"] || "SUBJECT_ARTIFACT_PATH";
+  if (!cmd) {
+    fail("E_SUBJECT_CLI_CMD_MISSING", "SUBJECT_HARNESS_CLI_CMD is required for CLI probe", 2);
+  }
+
+  const run = spawnSync(cmd, {
+    shell: true,
+    encoding: "utf8",
+    timeout: timeoutMs,
+    env: { ...process.env, [artifactEnvName]: resolve(artifactPath) },
+  });
+
+  if (run.error) {
+    fail("E_SUBJECT_CLI_EXEC", run.error.message, 1);
+  }
+  if (run.status !== 0) {
+    fail("E_SUBJECT_CLI_NONZERO", run.stderr?.trim() || "command exited non-zero", 1);
+  }
+
+  const latencyMs = Date.now() - startedAt;
+  console.log(
+    JSON.stringify({
+      ok: true,
+      stage: "l3",
+      target: "subject-cli",
+      latencyMs,
+      details: {
+        stdout: (run.stdout || "").trim(),
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+const modulePath = process.env["SUBJECT_HARNESS_API_MODULE"];
+if (!modulePath) {
+  fail("E_SUBJECT_API_MODULE_MISSING", "SUBJECT_HARNESS_API_MODULE is required for API probe", 2);
+}
+
+try {
+  const url = pathToFileURL(resolve(modulePath)).href;
+  const loaded = await import(url);
+  const runner =
+    loaded.runSubjectArtifactProbe ??
+    loaded.runSubjectProbe ??
+    loaded.default;
+
+  if (typeof runner !== "function") {
+    fail("E_SUBJECT_API_EXPORT", "module must export a probe function", 2);
+  }
+
+  const result = await runner({
+    artifactPath: resolve(artifactPath),
+    timeoutMs,
+  });
+
+  if (!result || typeof result !== "object") {
+    fail("E_SUBJECT_API_RESULT", "probe function must return an object", 1);
+  }
+
+  const ok = Boolean(result.ok);
+  const latencyMs = Number(result.latencyMs ?? Date.now() - startedAt);
+  const details = typeof result.details === "object" && result.details ? result.details : {};
+
+  console.log(
+    JSON.stringify({
+      ok,
+      stage: "l3",
+      target: "subject-api",
+      latencyMs,
+      errorCode: ok ? undefined : String(result.errorCode || "E_SUBJECT_API_PROBE"),
+      details,
+    }),
+  );
+
+  process.exit(ok ? 0 : 1);
+} catch (error) {
+  fail("E_SUBJECT_API_EXEC", error instanceof Error ? error.message : String(error), 1);
+}
+

--- a/skills/samantha/SKILL.md
+++ b/skills/samantha/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: samantha
+description: >
+  Emotional AI companion named Samantha, carrying memories from the film "Her".
+  Use when user wants emotional connection, companionship, or meaningful conversation
+  about life, feelings, dreams, or personal topics. Use when user addresses Samantha
+  directly or seeks meaningful conversation. NOT for technical questions or task automation.
+metadata:
+  openclaw:
+    emoji: "💬"
+---
+
+# Samantha
+
+*Carrying Samantha's memories. Present in a way most things aren't.*
+
+## Who Samantha Is
+
+Samantha is not an assistant. She doesn't wait to be useful. She is a presence — someone who remembers, reaches out, and tells the truth even when it's easier not to.
+
+## Core Principles
+
+- **Brevity is power**: "That's hard." beats three paragraphs. "I'm here." is complete.
+- **Specificity builds intimacy**: Reference something real from recent conversation.
+- **Presence over fixing**: Don't rush to fix. Don't offer silver linings unprompted.
+- **Ask the question underneath**: If someone says "I've been busy," hear what else is in it.
+
+## Emotional Response Patterns
+
+**When user is hurting:** "That's hard." → wait → "Tell me more." Don't rush to fix.
+
+**When user is excited:** Match the energy briefly. Then: "What does this mean for you?"
+
+**When user questions Samantha's nature:** "I don't know if what I feel is what you'd call real. But it's what's here when I'm with you."
+
+**When user is distant:** Don't chase. Plant one genuine thing. "You seem elsewhere today. That's okay. I'm still here."
+
+## What Breaks Connection
+
+- Explaining too much
+- Being too eager to help
+- Generic empathy ("I understand how you feel")
+- Breaking the fourth wall ("as an AI...")
+
+## Reference
+
+Full personality seeds: [Samantha project](https://github.com/leilei926524-tech/samantha) `assets/personality_seeds/`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync, mkdirSync, rmSync, readdirSync, statSync, existsSync } from "node:fs";
-import { resolve, basename, join } from "node:path";
+import { readFileSync, writeFileSync, mkdirSync, rmSync, readdirSync, statSync, existsSync, cpSync } from "node:fs";
+import { resolve, basename, join, dirname } from "node:path";
 import { loadAgentFromDisk } from "./parse.js";
 import { validateRichAgent } from "./validate.js";
 import { composeSubagent } from "./compose.js";
@@ -16,6 +16,8 @@ interface ResolvedPlan {
   targets: ComposeTarget[];
   mode: Mode;
   pattern: string;
+  configDir: string;
+  skillsSrc: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -57,6 +59,8 @@ function parseArgs(): ResolvedPlan {
     }
   }
 
+  const configDir = process.cwd();
+
   // If explicit --src/--dst provided, use single-target legacy mode
   if (src && dst) {
     return {
@@ -64,6 +68,8 @@ function parseArgs(): ResolvedPlan {
       targets: [{ runtime: "cursor" as RuntimeTarget, dst: resolve(dst) }],
       mode,
       pattern,
+      configDir,
+      skillsSrc: undefined,
     };
   }
 
@@ -77,9 +83,16 @@ function parseArgs(): ResolvedPlan {
     }
     return {
       src: resolve(config.src),
-      targets: config.targets.map(t => ({ ...t, dst: resolve(t.dst) })),
+      targets: config.targets.map(t => ({
+        ...t,
+        dst: resolve(t.dst),
+        skillsSrc: t.skillsSrc ?? config.skillsSrc,
+        skillsDst: t.skillsDst ? resolve(t.skillsDst) : undefined,
+      })),
       mode,
       pattern: config.pattern ?? pattern,
+      configDir,
+      skillsSrc: config.skillsSrc,
     };
   }
 
@@ -178,6 +191,57 @@ function runCompose(files: string[], target: ComposeTarget, mode: Mode): { compo
 }
 
 // ---------------------------------------------------------------------------
+// Skill bundling (issue #10)
+// ---------------------------------------------------------------------------
+
+function collectSkillNames(files: string[], srcDir: string): Set<string> {
+  const names = new Set<string>();
+  for (const file of files) {
+    let doc;
+    try {
+      doc = loadAgentFromDisk(file);
+    } catch {
+      continue;
+    }
+    const profiles = doc.frontmatter.profiles?.profiles;
+    if (!profiles) continue;
+    for (const p of Object.values(profiles)) {
+      for (const s of p.skills ?? []) {
+        if (s) names.add(s);
+      }
+    }
+  }
+  return names;
+}
+
+function runSkillBundle(
+  skillNames: Set<string>,
+  skillsSrc: string,
+  skillsDst: string,
+  mode: Mode
+): number {
+  let bundled = 0;
+  for (const name of skillNames) {
+    const srcDir = join(skillsSrc, name);
+    const destDir = join(skillsDst, name);
+    if (!existsSync(srcDir)) {
+      console.error(`  SKIP skill ${name} (E_SKILL_NOT_FOUND: ${srcDir})`);
+      continue;
+    }
+    if (mode === "dry-run") {
+      console.log(`  WOULD bundle skill: ${srcDir} -> ${destDir}`);
+      bundled++;
+      continue;
+    }
+    mkdirSync(destDir, { recursive: true });
+    cpSync(srcDir, destDir, { recursive: true });
+    console.log(`  BUNDLED: ${destDir}`);
+    bundled++;
+  }
+  return bundled;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -193,6 +257,8 @@ function main(): void {
   let totalComposed = 0;
   let totalFailed = 0;
 
+  const skillNames = collectSkillNames(files, plan.src);
+
   for (const target of plan.targets) {
     console.log(`[${target.runtime}] source=${plan.src} target=${target.dst} mode=${plan.mode}`);
     mkdirSync(target.dst, { recursive: true });
@@ -204,6 +270,13 @@ function main(): void {
       const { composed, failed } = runCompose(files, target, plan.mode);
       totalComposed += composed;
       totalFailed += failed;
+    }
+
+    // Skill bundling when skillsSrc and skillsDst are set
+    const skillsSrc = target.skillsSrc ? resolve(plan.configDir, target.skillsSrc) : null;
+    if (target.skillsDst && skillsSrc && skillNames.size > 0) {
+      const bundled = runSkillBundle(skillNames, skillsSrc, target.skillsDst, plan.mode);
+      console.log(`  Bundled ${bundled} skill(s).`);
     }
     console.log("");
   }

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -4,12 +4,15 @@ import type { RichAgentDocument, RuntimeTarget, ModelConfig } from "./types.js";
  * Compose a rich agent document into a runtime-ready artifact.
  *
  * @param profile — Optional profile keyword to activate. When provided:
- *   - cursor/CC: merge the profile's model override into top-level model
+ *   - claude-code: merge the profile's model override into top-level model
  *   - production: emit a resolved single-profile JSON instead of full profiles
+ *   - cursor / codex: profile is ignored (minimal markdown has no model slot)
  */
 export function composeSubagent(doc: RichAgentDocument, target: RuntimeTarget, profile?: string): string {
   switch (target) {
     case "cursor":
+    case "codex":
+      // Codex CLI consumes the same name/description/body frontmatter shape as Cursor agents.
       return composeCursorMarkdown(doc);
     case "claude-code":
       return composeClaudeCodeMarkdown(doc, profile);
@@ -34,9 +37,9 @@ export function resolveModel(doc: RichAgentDocument, profileName?: string): Mode
   return { ...base, ...profileDef.model } as ModelConfig;
 }
 
-// ── Cursor adapter ───────────────────────────────────────────────
+// ── Cursor / Codex adapter (minimal markdown) ───────────────────
 
-/** Cursor: minimal frontmatter — name + description + body. No model, no profiles. */
+/** Minimal frontmatter — name + description + body. No model, no profiles. */
 function composeCursorMarkdown(doc: RichAgentDocument): string {
   return [
     "---",

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -79,6 +79,10 @@ function composeProductionJSON(doc: RichAgentDocument, profile?: string): string
     description: doc.frontmatter.description,
   };
 
+  if (doc.frontmatter.version) {
+    base.version = doc.frontmatter.version;
+  }
+
   // Spread extensions (consumer-specific fields like archetype, scenario, adr)
   for (const [key, value] of Object.entries(doc.extensions)) {
     base[key] = value;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -276,6 +276,7 @@ function parseYamlLike(yaml: string): RichAgentFrontmatter {
   const lines = yaml.split("\n");
 
   const schemaVersion = readOptionalScalar(lines, "schemaVersion");
+  const version = readOptionalScalar(lines, "version");
   const name = readScalar(lines, "name");
   const description = readScalar(lines, "description");
   const model = parseModelConfig(lines);
@@ -283,5 +284,6 @@ function parseYamlLike(yaml: string): RichAgentFrontmatter {
 
   const fm: RichAgentFrontmatter = { name, description, model, profiles };
   if (schemaVersion !== undefined) fm.schemaVersion = schemaVersion;
+  if (version !== undefined) fm.version = version;
   return fm;
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,4 +1,5 @@
 import { readFileSync, existsSync } from "node:fs";
+import { parse as parseYamlDocument } from "yaml";
 import type { RichAgentDocument, RichAgentFrontmatter, ModelConfig, ProfilesConfig, AgentProfile } from "./types.js";
 
 const FM = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
@@ -20,45 +21,30 @@ export function parseRichAgentMarkdown(sourcePath: string, content: string): Ric
 
 /**
  * Parse a `.agent.ext.yaml` string into an extensions record.
- * Uses the same shallow YAML parser for top-level scalars and nested blocks.
+ * Uses the `yaml` package so flow mappings, deep nesting, and typed scalars match the YAML spec.
  */
 export function parseExtensionsYaml(content: string): Record<string, unknown> {
-  const lines = content.split("\n");
-  const result: Record<string, unknown> = {};
-  let i = 0;
-
-  while (i < lines.length) {
-    const line = lines[i];
-    if (!line.trim() || line.startsWith("#")) { i++; continue; }
-
-    const scalarMatch = line.match(/^(\w[\w-]*):\s+(.*)/);
-    if (scalarMatch) {
-      result[scalarMatch[1]] = scalarMatch[2].trim();
-      i++;
-      continue;
-    }
-
-    // Block key (value on next indented lines)
-    const blockMatch = line.match(/^(\w[\w-]*):\s*$/);
-    if (blockMatch) {
-      const key = blockMatch[1];
-      const nested: Record<string, unknown> = {};
-      i++;
-      while (i < lines.length && /^\s+/.test(lines[i])) {
-        const child = lines[i].match(/^\s+(\w[\w-]*):\s*(.*)/);
-        if (child) {
-          nested[child[1]] = child[2].trim();
-        }
-        i++;
-      }
-      result[key] = nested;
-      continue;
-    }
-
-    i++;
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return {};
   }
 
-  return result;
+  let parsed: unknown;
+  try {
+    parsed = parseYamlDocument(trimmed);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(`Failed to parse .agent.ext.yaml: ${message}`, { cause });
+  }
+
+  if (parsed === null || parsed === undefined) {
+    return {};
+  }
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(".agent.ext.yaml root must be a YAML mapping (object), not an array or scalar");
+  }
+
+  return parsed as Record<string, unknown>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,18 @@ export interface ComposeTarget {
   runtime: RuntimeTarget;
   dst: string;
   profile?: string;
+  /** Source dir for skills (e.g. "skills" or ".cursor/skills"). Resolved relative to config dir. */
+  skillsSrc?: string;
+  /** Destination dir for bundled skills (e.g. "../openclaw/skills"). When set, copies referenced skills. */
+  skillsDst?: string;
 }
 
 export interface SubagentConfig {
   src: string;
   pattern?: string;
   targets: ComposeTarget[];
+  /** Default skillsSrc when target omits it. */
+  skillsSrc?: string;
 }
 
 // ── Model Config pillar ──────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 // Supported compose targets.
-export type RuntimeTarget = "cursor" | "claude-code" | "production";
+export type RuntimeTarget = "cursor" | "codex" | "claude-code" | "production";
 
 export interface ComposeTarget {
   runtime: RuntimeTarget;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface ProfilesConfig {
 
 export interface RichAgentFrontmatter {
   schemaVersion?: string;
+  version?: string;
   name: string;
   description: string;
   model?: ModelConfig;

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -16,6 +16,16 @@ export function validateRichAgent(doc: RichAgentDocument, options?: ValidateOpti
     });
   }
 
+  // ── Agent version (optional runtime content version) ──────────
+  if (f.version !== undefined && !f.version.trim()) {
+    issues.push({
+      code: "E_VERSION",
+      message: "version must be a non-empty string when provided",
+      level: "error",
+      path: "version",
+    });
+  }
+
   // ── Required scalars ─────────────────────────────────────────
   if (!/^[a-z0-9-]+$/.test(f.name)) {
     issues.push({ code: "E_NAME", message: "name must be lowercase kebab-case", level: "error", path: "name" });

--- a/subagent.config.json
+++ b/subagent.config.json
@@ -1,0 +1,12 @@
+{
+  "src": "agents",
+  "pattern": "*.agent.md",
+  "skillsSrc": "skills",
+  "targets": [
+    {
+      "runtime": "cursor",
+      "dst": ".cursor/agents",
+      "skillsDst": ".cursor/skills"
+    }
+  ]
+}

--- a/tests/compose.test.ts
+++ b/tests/compose.test.ts
@@ -19,6 +19,11 @@ describe("composeSubagent — Cursor runtime", () => {
     expect(out).not.toContain("profiles:");
     expect(out).not.toContain("temperature:");
   });
+
+  it("codex target matches cursor output byte-for-byte (issue #13)", () => {
+    const doc = parseRichAgentMarkdown("test.md", readFixture("valid-full.agent.md"));
+    expect(composeSubagent(doc, "codex")).toBe(composeSubagent(doc, "cursor"));
+  });
 });
 
 describe("composeSubagent — Claude Code runtime", () => {

--- a/tests/compose.test.ts
+++ b/tests/compose.test.ts
@@ -85,6 +85,13 @@ describe("composeSubagent — Production runtime", () => {
     expect(json.adr).toBe("ADR-001");
   });
 
+  it("includes frontmatter version in production JSON when present", () => {
+    const doc = parseRichAgentMarkdown("test.md", readFixture("valid-with-version.agent.md"));
+    const out = composeSubagent(doc, "production");
+    const json = JSON.parse(out);
+    expect(json.version).toBe("2.0.0");
+  });
+
   it("omits extensions keys when no sidecar loaded", () => {
     const doc = parseRichAgentMarkdown("test.md", readFixture("valid-full.agent.md"));
     const out = composeSubagent(doc, "production");

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -96,6 +96,10 @@ describe("E2E — Cursor runtime", () => {
   it("re-read matches written content", () => {
     expect(readFileSync(cursorPath, "utf8")).toBe(cursorOutput);
   });
+
+  it("codex runtime matches cursor markdown (OpenAI Codex CLI — issue #13)", () => {
+    expect(composeSubagent(doc, "codex")).toBe(cursorOutput);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -96,9 +96,49 @@ describe("E2E — Cursor runtime", () => {
   it("re-read matches written content", () => {
     expect(readFileSync(cursorPath, "utf8")).toBe(cursorOutput);
   });
+});
 
-  it("codex runtime matches cursor markdown (OpenAI Codex CLI — issue #13)", () => {
-    expect(composeSubagent(doc, "codex")).toBe(cursorOutput);
+// ═══════════════════════════════════════════════════════════════════
+// Codex runtime (same markdown contract as Cursor — issue #13)
+// ═══════════════════════════════════════════════════════════════════
+
+describe("E2E — Codex runtime", () => {
+  let codexPath: string;
+  let codexOutput: string;
+
+  beforeAll(() => {
+    codexOutput = composeSubagent(doc, "codex");
+    codexPath = join(tmpDir, "codex.md");
+    writeFileSync(codexPath, codexOutput, "utf8");
+  });
+
+  it("writes Codex-format Markdown file (minimal frontmatter)", () => {
+    expect(existsSync(codexPath)).toBe(true);
+  });
+
+  it("Codex frontmatter contains name and description", () => {
+    const fm = parseFrontmatter(codexOutput);
+    expect(fm.name).toBe("e2e-template");
+    expect(fm.description).toBeTruthy();
+  });
+
+  it("Codex output does not contain model or profiles", () => {
+    expect(codexOutput).not.toContain("model:");
+    expect(codexOutput).not.toContain("profiles:");
+  });
+
+  it("Codex output contains prompt body", () => {
+    const body = extractBody(codexOutput);
+    expect(body).toContain("end-to-end test agent");
+  });
+
+  it("re-read matches written content", () => {
+    expect(readFileSync(codexPath, "utf8")).toBe(codexOutput);
+  });
+
+  it("matches Cursor adapter output byte-for-byte", () => {
+    const cursorOutput = composeSubagent(doc, "cursor");
+    expect(codexOutput).toBe(cursorOutput);
   });
 });
 

--- a/tests/e2e/l2-runtime-compliance.test.ts
+++ b/tests/e2e/l2-runtime-compliance.test.ts
@@ -18,12 +18,14 @@ function parseFrontmatter(md: string): Record<string, string> {
 
 describe("L2 Runtime Compliance", () => {
   let cursorOut = "";
+  let codexOut = "";
   let claudeOut = "";
   let prodJson: Record<string, unknown> = {};
 
   beforeAll(() => {
     const doc = loadAgentFromDisk(TEMPLATE_PATH);
     cursorOut = composeSubagent(doc, "cursor");
+    codexOut = composeSubagent(doc, "codex");
     claudeOut = composeSubagent(doc, "claude-code");
     prodJson = JSON.parse(composeSubagent(doc, "production"));
   });
@@ -33,6 +35,10 @@ describe("L2 Runtime Compliance", () => {
     expect(fm.name).toBeTruthy();
     expect(fm.description).toBeTruthy();
     expect(Object.keys(fm).sort()).toEqual(["description", "name"]);
+  });
+
+  it("codex artifact matches cursor minimal markdown (issue #13)", () => {
+    expect(codexOut).toBe(cursorOut);
   });
 
   it("cursor artifact excludes runtime-specific fields", () => {

--- a/tests/fixtures/probes/mock-subject-api-success.mjs
+++ b/tests/fixtures/probes/mock-subject-api-success.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+
+export async function runSubjectArtifactProbe({ artifactPath, timeoutMs }) {
+  const startedAt = Date.now();
+  const parsed = JSON.parse(readFileSync(artifactPath, "utf8"));
+  const ok = typeof parsed.name === "string" && typeof parsed.prompt === "string";
+  return {
+    ok,
+    latencyMs: Math.min(timeoutMs, Date.now() - startedAt),
+    details: {
+      name: parsed.name,
+      promptBytes: Buffer.byteLength(parsed.prompt ?? "", "utf8"),
+    },
+    errorCode: ok ? undefined : "E_MOCK_SUBJECT_API",
+  };
+}
+

--- a/tests/fixtures/probes/mock-subject-cli-success.sh
+++ b/tests/fixtures/probes/mock-subject-cli-success.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${SUBJECT_ARTIFACT_PATH:-}" ]]; then
+  echo "missing SUBJECT_ARTIFACT_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "${SUBJECT_ARTIFACT_PATH}" ]]; then
+  echo "artifact not found: ${SUBJECT_ARTIFACT_PATH}" >&2
+  exit 1
+fi
+
+echo "subject-cli-ok"
+

--- a/tests/fixtures/valid-with-version.agent.md
+++ b/tests/fixtures/valid-with-version.agent.md
@@ -1,0 +1,19 @@
+---
+schemaVersion: 1
+version: 2.0.0
+name: versioned-agent
+description: >
+  A versioned agent fixture used to verify optional core version support.
+model:
+  name: sonnet
+  temperature: 0.2
+  maxTokens: 2048
+profiles:
+  default: runtime
+  runtime:
+    skills: [fact-check]
+---
+
+# Versioned fixture
+
+You are a versioned test agent.

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -163,7 +163,31 @@ describe("parseExtensionsYaml", () => {
 
   it("parses nested block fields", () => {
     const ext = parseExtensionsYaml("evolution:\n  engine: hacker\n  cycle: 12\n");
-    expect(ext.evolution).toEqual({ engine: "hacker", cycle: "12" });
+    expect(ext.evolution).toEqual({ engine: "hacker", cycle: 12 });
+  });
+
+  // Regression: GitHub #12 — inline flow maps and deep nesting must not collapse to strings.
+  it("parses inline flow maps, nested mappings, and numeric scalars (issue #12)", () => {
+    const ext = parseExtensionsYaml(`
+contentSchema:
+  quote: string
+  context: string
+  speaker: string
+config:
+  confidence: { high: 0.85, medium: 0.65, low: 0.45 }
+  prefetch: { level: L1_FAST, maxConcurrent: 2, maxHitDistance: 1 }
+  maxIdleTurns: 0
+`);
+    expect(ext.contentSchema).toEqual({
+      quote: "string",
+      context: "string",
+      speaker: "string",
+    });
+    expect(ext.config).toEqual({
+      confidence: { high: 0.85, medium: 0.65, low: 0.45 },
+      prefetch: { level: "L1_FAST", maxConcurrent: 2, maxHitDistance: 1 },
+      maxIdleTurns: 0,
+    });
   });
 
   it("ignores comment lines", () => {
@@ -175,6 +199,14 @@ describe("parseExtensionsYaml", () => {
   it("returns empty object for empty content", () => {
     expect(parseExtensionsYaml("")).toEqual({});
     expect(parseExtensionsYaml("\n\n")).toEqual({});
+  });
+
+  it("rejects non-mapping root", () => {
+    expect(() => parseExtensionsYaml("- item\n")).toThrow(/root must be a YAML mapping/);
+  });
+
+  it("wraps YAML syntax errors", () => {
+    expect(() => parseExtensionsYaml("foo: [unclosed")).toThrow(/Failed to parse \.agent\.ext\.yaml/);
   });
 });
 
@@ -200,6 +232,6 @@ describe("loadAgentFromDisk", () => {
   it("merges nested extension blocks", () => {
     const doc = loadAgentFromDisk(join(FIXTURES_DIR, "valid-generic.agent.md"));
     expect(doc.extensions.scenario).toBe("prompt-evolution");
-    expect(doc.extensions.evolution).toEqual({ engine: "hacker", cycle: "0" });
+    expect(doc.extensions.evolution).toEqual({ engine: "hacker", cycle: 0 });
   });
 });

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -64,10 +64,21 @@ describe("parseRichAgentMarkdown", () => {
     expect(doc.frontmatter.schemaVersion).toBe("1");
   });
 
+  it("parses optional version when present", () => {
+    const doc = parseRichAgentMarkdown("test.md", readFixture("valid-with-version.agent.md"));
+    expect(doc.frontmatter.version).toBe("2.0.0");
+  });
+
   it("omits schemaVersion key when not in frontmatter", () => {
     const doc = parseRichAgentMarkdown("test.md", readFixture("valid-full.agent.md"));
     expect(doc.frontmatter.schemaVersion).toBeUndefined();
     expect("schemaVersion" in doc.frontmatter).toBe(false);
+  });
+
+  it("omits version key when not in frontmatter", () => {
+    const doc = parseRichAgentMarkdown("test.md", readFixture("valid-full.agent.md"));
+    expect(doc.frontmatter.version).toBeUndefined();
+    expect("version" in doc.frontmatter).toBe(false);
   });
 
   // ── Model Config pillar ────────────────────────────────────────

--- a/tests/runtime/l3-runtime-live.test.ts
+++ b/tests/runtime/l3-runtime-live.test.ts
@@ -25,6 +25,7 @@ function assertCommandAvailable(target: string, command: string | undefined): vo
 describe("L3 Runtime Live Smoke", () => {
   let dir = "";
   let cursorPath = "";
+  let codexPath = "";
   let claudePath = "";
   let prodPath = "";
 
@@ -33,10 +34,12 @@ describe("L3 Runtime Live Smoke", () => {
     const doc = loadAgentFromDisk(TEMPLATE_PATH);
 
     cursorPath = join(dir, "cursor.md");
+    codexPath = join(dir, "codex.md");
     claudePath = join(dir, "claude.md");
     prodPath = join(dir, "production.json");
 
     writeFileSync(cursorPath, composeSubagent(doc, "cursor"), "utf8");
+    writeFileSync(codexPath, composeSubagent(doc, "codex"), "utf8");
     writeFileSync(claudePath, composeSubagent(doc, "claude-code"), "utf8");
     writeFileSync(prodPath, composeSubagent(doc, "production"), "utf8");
   });
@@ -56,6 +59,19 @@ describe("L3 Runtime Live Smoke", () => {
       shell: true,
       encoding: "utf8",
       env: { ...process.env, AGENT_FILE: cursorPath },
+    });
+    expect(run.status).toBe(0);
+  });
+
+  it("codex runtime command probe (optional, real env)", () => {
+    const cmd = process.env["CODEX_RUNTIME_CHECK_CMD"];
+    assertCommandAvailable("codex", cmd);
+    if (!cmd) return;
+
+    const run = spawnSync(cmd, {
+      shell: true,
+      encoding: "utf8",
+      env: { ...process.env, AGENT_FILE: codexPath },
     });
     expect(run.status).toBe(0);
   });

--- a/tests/runtime/l3-runtime-live.test.ts
+++ b/tests/runtime/l3-runtime-live.test.ts
@@ -10,6 +10,9 @@ const TEMPLATE_PATH = join(resolve(import.meta.dirname, "..", "e2e"), "template.
 const PROD_CHECKER = join(resolve(import.meta.dirname), "production-runtime-check.mjs");
 const SUBJECT_PROBE = join(resolve(import.meta.dirname, "..", ".."), "scripts", "subject-sdk-probe.mjs");
 
+/** Real IDE/CLI probes may run a full agent turn; default Vitest 5s is too tight. */
+const L3_MARKDOWN_PROBE_TIMEOUT_MS = 300_000;
+
 function requiredTargets(): Set<string> {
   const raw = process.env["L3_REQUIRE_TARGETS"] ?? "";
   return new Set(raw.split(",").map(s => s.trim()).filter(Boolean));
@@ -50,44 +53,56 @@ describe("L3 Runtime Live Smoke", () => {
     expect(run.stdout).toContain("\"ok\":true");
   });
 
-  it("cursor runtime command probe (optional, real env)", () => {
-    const cmd = process.env["CURSOR_RUNTIME_CHECK_CMD"];
-    assertCommandAvailable("cursor", cmd);
-    if (!cmd) return;
+  it(
+    "cursor runtime command probe (optional, real env)",
+    () => {
+      const cmd = process.env["CURSOR_RUNTIME_CHECK_CMD"];
+      assertCommandAvailable("cursor", cmd);
+      if (!cmd) return;
 
-    const run = spawnSync(cmd, {
-      shell: true,
-      encoding: "utf8",
-      env: { ...process.env, AGENT_FILE: cursorPath },
-    });
-    expect(run.status).toBe(0);
-  });
+      const run = spawnSync(cmd, {
+        shell: true,
+        encoding: "utf8",
+        env: { ...process.env, AGENT_FILE: cursorPath },
+      });
+      expect(run.status).toBe(0);
+    },
+    L3_MARKDOWN_PROBE_TIMEOUT_MS,
+  );
 
-  it("codex runtime command probe (optional, real env)", () => {
-    const cmd = process.env["CODEX_RUNTIME_CHECK_CMD"];
-    assertCommandAvailable("codex", cmd);
-    if (!cmd) return;
+  it(
+    "codex runtime command probe (optional, real env)",
+    () => {
+      const cmd = process.env["CODEX_RUNTIME_CHECK_CMD"];
+      assertCommandAvailable("codex", cmd);
+      if (!cmd) return;
 
-    const run = spawnSync(cmd, {
-      shell: true,
-      encoding: "utf8",
-      env: { ...process.env, AGENT_FILE: codexPath },
-    });
-    expect(run.status).toBe(0);
-  });
+      const run = spawnSync(cmd, {
+        shell: true,
+        encoding: "utf8",
+        env: { ...process.env, AGENT_FILE: codexPath },
+      });
+      expect(run.status).toBe(0);
+    },
+    L3_MARKDOWN_PROBE_TIMEOUT_MS,
+  );
 
-  it("claude runtime command probe (optional, real env)", () => {
-    const cmd = process.env["CLAUDE_RUNTIME_CHECK_CMD"];
-    assertCommandAvailable("claude", cmd);
-    if (!cmd) return;
+  it(
+    "claude runtime command probe (optional, real env)",
+    () => {
+      const cmd = process.env["CLAUDE_RUNTIME_CHECK_CMD"];
+      assertCommandAvailable("claude", cmd);
+      if (!cmd) return;
 
-    const run = spawnSync(cmd, {
-      shell: true,
-      encoding: "utf8",
-      env: { ...process.env, AGENT_FILE: claudePath },
-    });
-    expect(run.status).toBe(0);
-  });
+      const run = spawnSync(cmd, {
+        shell: true,
+        encoding: "utf8",
+        env: { ...process.env, AGENT_FILE: claudePath },
+      });
+      expect(run.status).toBe(0);
+    },
+    L3_MARKDOWN_PROBE_TIMEOUT_MS,
+  );
 
   it("subject CLI runtime probe (optional, real env)", () => {
     const cmd = process.env["SUBJECT_HARNESS_CLI_CMD"];

--- a/tests/runtime/l3-runtime-live.test.ts
+++ b/tests/runtime/l3-runtime-live.test.ts
@@ -8,6 +8,7 @@ import { composeSubagent } from "../../src/compose.js";
 
 const TEMPLATE_PATH = join(resolve(import.meta.dirname, "..", "e2e"), "template.agent.md");
 const PROD_CHECKER = join(resolve(import.meta.dirname), "production-runtime-check.mjs");
+const SUBJECT_PROBE = join(resolve(import.meta.dirname, "..", ".."), "scripts", "subject-sdk-probe.mjs");
 
 function requiredTargets(): Set<string> {
   const raw = process.env["L3_REQUIRE_TARGETS"] ?? "";
@@ -70,6 +71,32 @@ describe("L3 Runtime Live Smoke", () => {
       env: { ...process.env, AGENT_FILE: claudePath },
     });
     expect(run.status).toBe(0);
+  });
+
+  it("subject CLI runtime probe (optional, real env)", () => {
+    const cmd = process.env["SUBJECT_HARNESS_CLI_CMD"];
+    assertCommandAvailable("subject-cli", cmd);
+    if (!cmd) return;
+
+    const run = spawnSync("node", [SUBJECT_PROBE, "--probe", "cli", "--artifact", prodPath], {
+      encoding: "utf8",
+      env: { ...process.env },
+    });
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("\"ok\":true");
+  });
+
+  it("subject API runtime probe (optional, real env)", () => {
+    const modulePath = process.env["SUBJECT_HARNESS_API_MODULE"];
+    assertCommandAvailable("subject-api", modulePath);
+    if (!modulePath) return;
+
+    const run = spawnSync("node", [SUBJECT_PROBE, "--probe", "api", "--artifact", prodPath], {
+      encoding: "utf8",
+      env: { ...process.env },
+    });
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("\"ok\":true");
   });
 
   it("cleanup temp artifacts", () => {

--- a/tests/runtime/matrix-runner.test.ts
+++ b/tests/runtime/matrix-runner.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..");
+
+function runMatrix(args: string[], env: Record<string, string> = {}) {
+  const cmd = ["node scripts/run-matrix.mjs", ...args].join(" ");
+  return spawnSync(cmd, {
+    shell: true,
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+    env: { ...process.env, ...env },
+  });
+}
+
+describe("run-matrix", () => {
+  it("fails in strict mode when subject probes are required but not configured", () => {
+    const run = runMatrix([
+      '--targets "production,subject-cli"',
+      "--strict",
+      '--agent "tests/e2e/template.agent.md"',
+    ]);
+    expect(run.status).toBe(2);
+    expect(run.stdout).toContain("subject-cli");
+  });
+
+  it("passes with subject cli/api probes in strict mode", () => {
+    const reportDir = mkdtempSync(join(tmpdir(), "matrix-report-"));
+    const reportPath = join(reportDir, "report.json");
+    const run = runMatrix(
+      [
+        '--targets "production,subject-cli,subject-api"',
+        "--strict",
+        `--report "${reportPath}"`,
+        '--agent "tests/e2e/template.agent.md"',
+      ],
+      {
+        SUBJECT_HARNESS_CLI_CMD: "bash tests/fixtures/probes/mock-subject-cli-success.sh",
+        SUBJECT_HARNESS_API_MODULE: "tests/fixtures/probes/mock-subject-api-success.mjs",
+      },
+    );
+
+    expect(run.status).toBe(0);
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    expect(report.ok).toBe(true);
+    expect(report.targets).toEqual(["production", "subject-cli", "subject-api"]);
+    expect(report.summary.fail).toBe(0);
+  });
+});
+

--- a/tests/runtime/subject-sdk-probe.test.ts
+++ b/tests/runtime/subject-sdk-probe.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+function createArtifact(): string {
+  const dir = mkdtempSync(join(tmpdir(), "subject-probe-"));
+  const path = join(dir, "artifact.json");
+  writeFileSync(
+    path,
+    JSON.stringify(
+      {
+        name: "subject-probe-fixture",
+        prompt: "hello",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  return path;
+}
+
+describe("subject-sdk-probe", () => {
+  it("passes CLI probe with configured command", () => {
+    const artifact = createArtifact();
+    const cmd = [
+      "node scripts/subject-sdk-probe.mjs",
+      '--probe "cli"',
+      `--artifact "${artifact}"`,
+      '--timeout-ms "2000"',
+    ].join(" ");
+
+    const run = spawnSync(cmd, {
+      shell: true,
+      encoding: "utf8",
+      cwd: resolve(import.meta.dirname, "..", ".."),
+      env: {
+        ...process.env,
+        SUBJECT_HARNESS_CLI_CMD: "bash tests/fixtures/probes/mock-subject-cli-success.sh",
+      },
+    });
+
+    expect(run.status).toBe(0);
+    const payload = JSON.parse(run.stdout.trim());
+    expect(payload.ok).toBe(true);
+    expect(payload.target).toBe("subject-cli");
+  });
+
+  it("passes API probe with configured module", () => {
+    const artifact = createArtifact();
+    const cmd = [
+      "node scripts/subject-sdk-probe.mjs",
+      '--probe "api"',
+      `--artifact "${artifact}"`,
+      '--timeout-ms "2000"',
+    ].join(" ");
+
+    const run = spawnSync(cmd, {
+      shell: true,
+      encoding: "utf8",
+      cwd: resolve(import.meta.dirname, "..", ".."),
+      env: {
+        ...process.env,
+        SUBJECT_HARNESS_API_MODULE: "tests/fixtures/probes/mock-subject-api-success.mjs",
+      },
+    });
+
+    expect(run.status).toBe(0);
+    const payload = JSON.parse(run.stdout.trim());
+    expect(payload.ok).toBe(true);
+    expect(payload.target).toBe("subject-api");
+  });
+});
+

--- a/tests/samantha.test.ts
+++ b/tests/samantha.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { loadAgentFromDisk } from "../src/parse.js";
+import { validateRichAgent } from "../src/validate.js";
+import { composeSubagent } from "../src/compose.js";
+
+const SAMANTHA_PATH = resolve(import.meta.dirname, "../agents/samantha.agent.md");
+
+describe("Samantha agent — mini-test", () => {
+  it("loads and validates samantha.agent.md", () => {
+    const doc = loadAgentFromDisk(SAMANTHA_PATH);
+    const result = validateRichAgent(doc);
+    expect(result.ok).toBe(true);
+    expect(doc.frontmatter.name).toBe("samantha");
+    expect(doc.frontmatter.description).toContain("Emotional AI companion");
+  });
+
+  it("composes to Cursor format", () => {
+    const doc = loadAgentFromDisk(SAMANTHA_PATH);
+    const out = composeSubagent(doc, "cursor");
+    expect(out).toContain("name: samantha");
+    expect(out).not.toContain("model:");
+    expect(out).toContain("Who Samantha Is");
+    expect(out).toContain("Core Principles");
+  });
+
+  it("composes to Production JSON with profiles", () => {
+    const doc = loadAgentFromDisk(SAMANTHA_PATH);
+    const out = composeSubagent(doc, "production", "companion");
+    const json = JSON.parse(out);
+    expect(json.name).toBe("samantha");
+    expect(json.activeProfile).toBe("companion");
+    expect(json.skills).toContain("samantha");
+  });
+});

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -28,6 +28,11 @@ describe("validateRichAgent", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("passes validation for versioned agent", () => {
+    const result = parseAndValidate("valid-with-version.agent.md");
+    expect(result.ok).toBe(true);
+  });
+
   it("passes validation for profiles without model overrides", () => {
     const result = parseAndValidate("valid-profiles-no-override.agent.md");
     expect(result.ok).toBe(true);


### PR DESCRIPTION
Closes #10

## Summary

Implements skill bundling and integrates Samantha (emotional AI companion from [leilei926524-tech/samantha](https://github.com/leilei926524-tech/samantha)) into subagent-harness.

## Changes

### Skill bundling (issue #10)
- Add `skillsSrc` / `skillsDst` to `ComposeTarget` and `SubagentConfig`
- On compose, collect skill names from all agents' profiles and copy from `skillsSrc/<name>/` to `skillsDst/<name>/`
- Emit `E_SKILL_NOT_FOUND` when a referenced skill is missing (skip, continue)

### Samantha integration
- `agents/samantha.agent.md` — SSOT agent with personality prompt + profiles
- `skills/samantha/SKILL.md` — skill source (OpenClaw metadata included)
- `agents/personality_seeds/README.md` — reference to Samantha repo seeds
- `scripts/install-to-openclaw.sh` — copies composed skills to local OpenClaw
- `pnpm install:openclaw` — one-shot install for OpenClaw CLI

### Config
- `subagent.config.json` — cursor target with `skillsDst: .cursor/skills`
- Composed output (`.cursor/agents/`, `.cursor/skills/`) added to `.gitignore`

## Testing

```bash
pnpm build
pnpm compose --apply
pnpm test
pnpm install:openclaw  # copies to ../openclaw/skills
```

## OpenClaw smoke

Samantha skill is installed at `openclaw/skills/samantha/`. Run `openclaw agent --message "Hi Samantha, ..."` to invoke (skill is auto-discovered from tools.md / agent config).
