### PR TITLE
[codex] fix yaml frontmatter parsing

### DIFF
--- a/docs/YAML_SUBSET.md
+++ b/docs/YAML_SUBSET.md
@@ -1,55 +1,74 @@
-# Supported YAML Subset
+# YAML Support
 
-`subagent-harness` uses a **purpose-built YAML parser** (zero dependencies) optimized for
-`.agent.md` frontmatter and `.agent.ext.yaml` sidecar files. It intentionally supports only
-the YAML features needed by the agent definition format.
+`subagent-harness` parses `.agent.md` frontmatter and `.agent.ext.yaml` sidecars
+with the `yaml` package. The parser accepts standard YAML syntax, then normalizes
+only the fields owned by the harness protocol.
 
-## Supported Features
+## `.agent.md` frontmatter
 
-| Feature | Syntax | Example |
-|---------|--------|---------|
-| Scalar key-value | `key: value` | `name: my-agent` |
-| Quoted strings | `key: "value"` | `description: "A cool agent"` |
-| Folded block scalar | `key: >` | Multi-line → single line (spaces) |
-| Literal block scalar | `key: \|` | Multi-line → preserved newlines |
-| Nested block (1 level) | `parent:` + indented children | `model:` / `  name: sonnet` |
-| Multi-level nesting | Up to 3 levels | `profiles:` / `  live:` / `    skills: [...]` |
-| Inline arrays | `[a, b, c]` | `skills: [fact-check, cite]` |
-| Comments | `# comment` | Skipped in `.ext.yaml` parsing |
+The frontmatter root must be a YAML mapping. The harness reads these core fields:
 
-## Unsupported Features
+| Field | Shape | Notes |
+|-------|-------|-------|
+| `schemaVersion` | scalar | Optional; normalized to string |
+| `version` | scalar | Optional agent content version |
+| `name` | scalar | Required; validated as lowercase kebab-case |
+| `description` | scalar | Required |
+| `model` | mapping | Optional; `name`, `temperature`, `maxTokens` |
+| `profiles` | mapping | Optional; `default` plus profile mappings |
+| `profiles.<name>.skills` | sequence or comma-separated string | Empty sequence is allowed |
+| `profiles.<name>.model` | mapping | Optional model override |
 
-These standard YAML features are **not supported** and will be silently ignored or cause
-parse errors:
-
-| Feature | Syntax | Reason |
-|---------|--------|--------|
-| Anchors & aliases | `&anchor` / `*anchor` | No reuse pattern in agent definitions |
-| Multi-document streams | `---` / `...` as doc separators | `---` is reserved for frontmatter delimiters |
-| Merge keys | `<<: *base` | Not needed; profiles handle overrides |
-| Type tags | `!!str`, `!!int` | Values are coerced by the parser |
-| Flow mappings | `{key: value}` | Use block style instead |
-| Block sequences | `- item` | Use inline array `[a, b]` syntax |
-| Complex keys | `? key` | Not applicable |
-| Deeply nested blocks (>3 levels) | — | Flatten structure or use extensions |
-
-## Colons in Values
-
-Unquoted values containing colons (`:`) may cause incorrect parsing.
-When a value contains a colon, wrap it in double quotes:
+Standard YAML features such as quoted scalars, folded/literal block scalars,
+flow mappings, block sequences, comments, anchors, and aliases are supported by
+the parser.
 
 ```yaml
-# Safe
+---
+schemaVersion: 1
+name: yaml-agent
 description: "Handles HTTP responses: 200, 404, 500"
-
-# Risky — may split at the first colon
-description: Handles HTTP responses: 200, 404, 500
+model: { name: sonnet, temperature: 0.2, maxTokens: 1024 }
+profiles:
+  default: live
+  live:
+    skills: &coreSkills
+      - fact-check
+      - real-time-cite
+  review:
+    skills: *coreSkills
+    model: { name: opus, temperature: 0.7 }
+---
 ```
 
-## Design Rationale
+## `.agent.ext.yaml` sidecars
 
-The hand-rolled parser keeps `subagent-harness` at **zero runtime dependencies**.
-Agent definitions are a controlled format — the parser covers exactly the features
-the format requires. For consumers needing full YAML spec compliance, we recommend
-pre-processing files with a standard YAML library (`yaml` package) before passing
-parsed content to the harness API.
+Sidecar files also use the `yaml` package. The root must be a YAML mapping; the
+harness keeps the resulting object opaque and passes it through as `extensions`
+or spreads it into production JSON for backward compatibility.
+
+```yaml
+contentSchema:
+  quote: string
+  context: string
+config:
+  confidence: { high: 0.85, medium: 0.65, low: 0.45 }
+  maxIdleTurns: 5
+```
+
+## Protocol limits
+
+The parser accepts YAML, but the harness protocol is still intentionally small:
+
+| Feature | Status | Reason |
+|---------|--------|--------|
+| Unknown frontmatter keys | Ignored | Core frontmatter stays portable across runtimes |
+| YAML merge key `<<` | Not interpreted as profile inheritance | Profile inheritance belongs in explicit model/skill resolution |
+| Multi-document streams inside frontmatter | Not supported | `---` is reserved for Markdown frontmatter delimiters |
+| Domain validation for sidecars | Consumer-owned | Use `validateRichAgent(doc, { extensionValidator })` |
+
+When values contain colons or other YAML-significant characters, quote them:
+
+```yaml
+description: "Handles HTTP responses: 200, 404, 500"
+```

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -64,212 +64,176 @@ export function loadAgentFromDisk(mdPath: string): RichAgentDocument {
   return doc;
 }
 
-// ── Scalar readers ───────────────────────────────────────────────
+// ── Frontmatter parser (core fields only) ────────────────────────
 
-function readScalar(lines: string[], key: string): string {
-  for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(new RegExp(`^${key}:\\s*(.*)`));
-    if (!m) continue;
+type YamlMapping = Record<string, unknown>;
 
-    const value = m[1].trim();
+function parseYamlLike(yaml: string): RichAgentFrontmatter {
+  const root = parseYamlMapping(yaml, "frontmatter");
 
-    // Folded (>) or literal (|) block scalar
-    if (value === ">" || value === "|") {
-      const parts: string[] = [];
-      for (let j = i + 1; j < lines.length; j++) {
-        if (/^\s+/.test(lines[j])) {
-          parts.push(lines[j].trim());
-        } else {
-          break;
-        }
-      }
-      return parts.join(value === ">" ? " " : "\n");
-    }
+  const fm: RichAgentFrontmatter = {
+    name: readRequiredString(root, "name"),
+    description: readRequiredString(root, "description"),
+  };
 
-    if (!value) throw new Error(`Missing value for key: ${key}`);
-    return value.replace(/^"|"$/g, "");
-  }
-  throw new Error(`Missing required key: ${key}`);
+  const schemaVersion = readOptionalString(root, "schemaVersion");
+  if (schemaVersion !== undefined) fm.schemaVersion = schemaVersion;
+
+  const version = readOptionalString(root, "version");
+  if (version !== undefined) fm.version = version;
+
+  const model = parseModelConfig(root["model"], "model");
+  if (model !== undefined) fm.model = model;
+
+  const profiles = parseProfiles(root["profiles"], "profiles");
+  if (profiles !== undefined) fm.profiles = profiles;
+
+  return fm;
 }
 
-function readOptionalScalar(lines: string[], key: string): string | undefined {
+function parseYamlMapping(yaml: string, path: string): YamlMapping {
+  let parsed: unknown;
   try {
-    return readScalar(lines, key);
-  } catch {
+    parsed = parseYamlDocument(yaml);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(`Failed to parse .agent.md frontmatter: ${message}`, { cause });
+  }
+
+  return asMapping(parsed, path);
+}
+
+function asMapping(value: unknown, path: string): YamlMapping {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return value as YamlMapping;
+  }
+  throw new Error(`${path} must be a YAML mapping (object), not an array or scalar`);
+}
+
+function readRequiredString(map: YamlMapping, key: string): string {
+  if (!Object.prototype.hasOwnProperty.call(map, key)) {
+    throw new Error(`Missing required key: ${key}`);
+  }
+  return scalarToString(map[key], key);
+}
+
+function readOptionalString(map: YamlMapping, key: string): string | undefined {
+  if (!Object.prototype.hasOwnProperty.call(map, key) || map[key] === undefined) {
     return undefined;
   }
+  return scalarToString(map[key], key);
 }
 
-// ── Nested block reader ──────────────────────────────────────────
-
-function readNestedBlock(lines: string[], key: string): Record<string, string> | undefined {
-  let blockStart = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].match(new RegExp(`^${key}:\\s*$`))) {
-      blockStart = i + 1;
-      break;
-    }
-  }
-  if (blockStart < 0) return undefined;
-
-  const result: Record<string, string> = {};
-  for (let j = blockStart; j < lines.length; j++) {
-    const child = lines[j].match(/^\s+(\w+):\s*(.*)/);
-    if (!child) break;
-    result[child[1]] = child[2].trim();
-  }
-
-  return Object.keys(result).length > 0 ? result : undefined;
+function scalarToString(value: unknown, path: string): string {
+  if (value === null) return "";
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  throw new Error(`${path} must be a scalar string`);
 }
 
-// ── Model config parser ──────────────────────────────────────────
+function readOptionalNumber(map: YamlMapping, key: string, path: string): number | undefined {
+  if (!Object.prototype.hasOwnProperty.call(map, key) || map[key] === undefined || map[key] === null) {
+    return undefined;
+  }
 
-function buildModelFromBlock(block: Record<string, string>): ModelConfig {
-  const config: ModelConfig = { name: block["name"] ?? "" };
-  if (block["temperature"] !== undefined) {
-    config.temperature = parseFloat(block["temperature"]);
+  const value = map[key];
+  const n = typeof value === "number"
+    ? value
+    : typeof value === "string"
+      ? Number(value)
+      : Number.NaN;
+
+  if (!Number.isFinite(n)) {
+    throw new Error(`${path}.${key} must be a finite number`);
   }
-  if (block["maxTokens"] !== undefined) {
-    config.maxTokens = parseInt(block["maxTokens"], 10);
-  }
+  return n;
+}
+
+function parseModelConfig(value: unknown, path: string): ModelConfig | undefined {
+  if (value === undefined || value === null) return undefined;
+
+  const block = asMapping(value, path);
+  const config: ModelConfig = {
+    name: Object.prototype.hasOwnProperty.call(block, "name")
+      ? scalarToString(block["name"], `${path}.name`)
+      : "",
+  };
+
+  const temperature = readOptionalNumber(block, "temperature", path);
+  if (temperature !== undefined) config.temperature = temperature;
+
+  const maxTokens = readOptionalNumber(block, "maxTokens", path);
+  if (maxTokens !== undefined) config.maxTokens = maxTokens;
+
   return config;
 }
 
-function parseModelConfig(lines: string[]): ModelConfig | undefined {
-  const block = readNestedBlock(lines, "model");
-  if (!block) return undefined;
-  return buildModelFromBlock(block);
-}
+function parsePartialModelConfig(value: unknown, path: string): Partial<ModelConfig> | undefined {
+  if (value === undefined || value === null) return undefined;
 
-// ── Inline array parser ──────────────────────────────────────────
+  const block = asMapping(value, path);
+  const config: Partial<ModelConfig> = {};
 
-function parseInlineArray(value: string): string[] {
-  const inner = value.replace(/^\[/, "").replace(/\]$/, "").trim();
-  if (!inner) return [];
-  return inner.split(",").map(s => s.trim()).filter(Boolean);
-}
-
-// ── Profiles parser ──────────────────────────────────────────────
-
-function parseProfiles(lines: string[]): ProfilesConfig | undefined {
-  let blockStart = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (/^profiles:\s*$/.test(lines[i])) {
-      blockStart = i + 1;
-      break;
-    }
+  if (Object.prototype.hasOwnProperty.call(block, "name")) {
+    config.name = scalarToString(block["name"], `${path}.name`);
   }
-  if (blockStart < 0) return undefined;
 
-  const childIndentMatch = lines[blockStart]?.match(/^(\s+)/);
-  if (!childIndentMatch) return undefined;
-  const childIndent = childIndentMatch[1].length;
+  const temperature = readOptionalNumber(block, "temperature", path);
+  if (temperature !== undefined) config.temperature = temperature;
 
-  let defaultProfile: string | undefined;
+  const maxTokens = readOptionalNumber(block, "maxTokens", path);
+  if (maxTokens !== undefined) config.maxTokens = maxTokens;
+
+  return Object.keys(config).length > 0 ? config : undefined;
+}
+
+function parseProfiles(value: unknown, path: string): ProfilesConfig | undefined {
+  if (value === undefined || value === null) return undefined;
+
+  const block = asMapping(value, path);
   const profiles: Record<string, AgentProfile> = {};
+  let defaultProfile: string | undefined;
 
-  let i = blockStart;
-  while (i < lines.length) {
-    const line = lines[i];
-    if (!/^\s/.test(line)) break;
-
-    const childMatch = line.match(new RegExp(`^\\s{${childIndent}}(\\w[\\w-]*):\\s*(.*)`));
-    if (!childMatch) break;
-
-    const key = childMatch[1];
-    const value = childMatch[2].trim();
-
-    if (key === "default") {
-      defaultProfile = value;
-      i++;
+  for (const [name, rawProfile] of Object.entries(block)) {
+    if (name === "default") {
+      defaultProfile = scalarToString(rawProfile, `${path}.default`);
       continue;
     }
 
-    const { _endLine, ...profile } = parseProfileBody(lines, i + 1, childIndent);
-    profiles[key] = profile;
-    i = _endLine;
+    const profileBlock = asMapping(rawProfile, `${path}.${name}`);
+    const profile: AgentProfile = {
+      skills: parseSkills(profileBlock["skills"], `${path}.${name}.skills`),
+    };
+
+    const model = parsePartialModelConfig(profileBlock["model"], `${path}.${name}.model`);
+    if (model !== undefined) {
+      profile.model = model;
+    }
+
+    profiles[name] = profile;
   }
 
   if (Object.keys(profiles).length === 0) return undefined;
 
-  return { default: defaultProfile, profiles };
+  const result: ProfilesConfig = { profiles };
+  if (defaultProfile !== undefined) {
+    result.default = defaultProfile;
+  }
+  return result;
 }
 
-interface ProfileParseResult extends AgentProfile {
-  _endLine: number;
-}
+function parseSkills(value: unknown, path: string): string[] {
+  if (value === undefined || value === null) return [];
 
-function parseProfileBody(lines: string[], start: number, parentIndent: number): ProfileParseResult {
-  const subIndent = parentIndent + 2;
-  let skills: string[] = [];
-  let model: Partial<ModelConfig> | undefined;
-  let i = start;
-
-  while (i < lines.length) {
-    const line = lines[i];
-    const indentMatch = line.match(/^(\s+)/);
-    if (!indentMatch || indentMatch[1].length < subIndent) break;
-
-    const subMatch = line.match(new RegExp(`^\\s{${subIndent}}(\\w+):\\s*(.*)`));
-    if (!subMatch) break;
-
-    const key = subMatch[1];
-    const value = subMatch[2].trim();
-
-    if (key === "skills") {
-      skills = parseInlineArray(value);
-      i++;
-    } else if (key === "model") {
-      const modelBlock = parseSubModelBlock(lines, i + 1, subIndent);
-      model = modelBlock.config;
-      i = modelBlock.endLine;
-    } else {
-      i++;
-    }
+  if (Array.isArray(value)) {
+    return value.map((item, index) => scalarToString(item, `${path}[${index}]`));
   }
 
-  return { skills, model, _endLine: i };
-}
-
-function parseSubModelBlock(lines: string[], start: number, parentIndent: number): { config: Partial<ModelConfig>; endLine: number } {
-  const subIndent = parentIndent + 2;
-  const block: Record<string, string> = {};
-  let i = start;
-
-  while (i < lines.length) {
-    const line = lines[i];
-    const indentMatch = line.match(/^(\s+)/);
-    if (!indentMatch || indentMatch[1].length < subIndent) break;
-
-    const m = line.match(new RegExp(`^\\s{${subIndent}}(\\w+):\\s*(.*)`));
-    if (!m) break;
-
-    block[m[1]] = m[2].trim();
-    i++;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    return trimmed.split(",").map(s => s.trim()).filter(Boolean);
   }
 
-  const config: Partial<ModelConfig> = {};
-  if (block["name"]) config.name = block["name"];
-  if (block["temperature"] !== undefined) config.temperature = parseFloat(block["temperature"]);
-  if (block["maxTokens"] !== undefined) config.maxTokens = parseInt(block["maxTokens"], 10);
-
-  return { config: Object.keys(config).length > 0 ? config : undefined as unknown as Partial<ModelConfig>, endLine: i };
-}
-
-// ── Main parser (core fields only) ───────────────────────────────
-
-function parseYamlLike(yaml: string): RichAgentFrontmatter {
-  const lines = yaml.split("\n");
-
-  const schemaVersion = readOptionalScalar(lines, "schemaVersion");
-  const version = readOptionalScalar(lines, "version");
-  const name = readScalar(lines, "name");
-  const description = readScalar(lines, "description");
-  const model = parseModelConfig(lines);
-  const profiles = parseProfiles(lines);
-
-  const fm: RichAgentFrontmatter = { name, description, model, profiles };
-  if (schemaVersion !== undefined) fm.schemaVersion = schemaVersion;
-  if (version !== undefined) fm.version = version;
-  return fm;
+  throw new Error(`${path} must be a YAML sequence or comma-separated string`);
 }

--- a/tests/cli-check.test.ts
+++ b/tests/cli-check.test.ts
@@ -1,23 +1,28 @@
 /**
  * Integration tests for the --check CLI flag (issue #20).
  *
- * Spawns the CLI via bun so TypeScript runs without a prior build step.
+ * Prefer the built CLI so CI does not depend on Bun being installed.
  * Each test sets up its own temp dir to keep state isolated.
  */
 
 import { describe, it, expect, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, utimesSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, utimesSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 
-const CLI = resolve(import.meta.dirname, "../src/cli.ts");
+const SOURCE_CLI = resolve(import.meta.dirname, "../src/cli.ts");
+const BUILT_CLI = resolve(import.meta.dirname, "../dist/cli.js");
 const FIXTURE_AGENT = resolve(import.meta.dirname, "fixtures/valid-minimal.agent.md");
 const FIXTURE_CONTENT = readFileSync(FIXTURE_AGENT, "utf8");
 
 /** Invoke the CLI and return { stdout, stderr, status }. */
 function runCli(args: string[], cwd: string) {
-  const result = spawnSync("bun", ["run", "--no-install", CLI, ...args], {
+  const [command, commandArgs] = existsSync(BUILT_CLI)
+    ? [process.execPath, [BUILT_CLI, ...args]]
+    : ["bun", ["run", "--no-install", SOURCE_CLI, ...args]];
+
+  const result = spawnSync(command, commandArgs, {
     cwd,
     encoding: "utf8",
     timeout: 15_000,

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -39,6 +39,53 @@ describe("parseRichAgentMarkdown", () => {
     expect(doc.frontmatter.description).toBe("Bare minimum required fields only");
   });
 
+  it("parses standard YAML frontmatter features", () => {
+    const doc = parseRichAgentMarkdown("test.md", `---
+schemaVersion: 1
+name: yaml-agent
+description: "Handles HTTP responses: 200, 404, 500"
+model: { name: sonnet, temperature: 0.2, maxTokens: 1024 }
+profiles:
+  default: live
+  live:
+    skills: &coreSkills
+      - fact-check
+      - real-time-cite
+  review:
+    skills: *coreSkills
+    model: { name: opus, temperature: 0.7 }
+---
+
+Use the YAML parser for core frontmatter.
+`);
+
+    expect(doc.frontmatter.schemaVersion).toBe("1");
+    expect(doc.frontmatter.description).toBe("Handles HTTP responses: 200, 404, 500");
+    expect(doc.frontmatter.model).toEqual({ name: "sonnet", temperature: 0.2, maxTokens: 1024 });
+    expect(doc.frontmatter.profiles?.default).toBe("live");
+    expect(doc.frontmatter.profiles?.profiles["live"].skills).toEqual(["fact-check", "real-time-cite"]);
+    expect(doc.frontmatter.profiles?.profiles["review"].skills).toEqual(["fact-check", "real-time-cite"]);
+    expect(doc.frontmatter.profiles?.profiles["review"].model).toEqual({ name: "opus", temperature: 0.7 });
+  });
+
+  it("parses block sequence skills in profiles", () => {
+    const doc = parseRichAgentMarkdown("test.md", `---
+name: sequence-skills
+description: Agent with block sequence skills
+profiles:
+  default: live
+  live:
+    skills:
+      - detect
+      - classify
+---
+
+Use block sequence skills.
+`);
+
+    expect(doc.frontmatter.profiles?.profiles["live"].skills).toEqual(["detect", "classify"]);
+  });
+
   it("stores sourcePath from argument", () => {
     const doc = parseRichAgentMarkdown("/some/path.md", readFixture("valid-minimal.agent.md"));
     expect(doc.sourcePath).toBe("/some/path.md");
@@ -147,6 +194,25 @@ describe("parseRichAgentMarkdown", () => {
   it("throws on missing required key (name)", () => {
     expect(() => parseRichAgentMarkdown("bad.md", readFixture("invalid-no-name.agent.md")))
       .toThrow("Missing required key: name");
+  });
+
+  it("throws on non-mapping frontmatter root", () => {
+    expect(() => parseRichAgentMarkdown("bad.md", `---
+- name
+---
+
+Body
+`)).toThrow("frontmatter must be a YAML mapping");
+  });
+
+  it("wraps YAML syntax errors in frontmatter", () => {
+    expect(() => parseRichAgentMarkdown("bad.md", `---
+name: [unclosed
+description: Bad YAML
+---
+
+Body
+`)).toThrow(/Failed to parse \.agent\.md frontmatter/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace the hand-rolled `.agent.md` frontmatter parser with `yaml`-backed parsing plus explicit protocol shape normalization.
- Add regression coverage for quoted colon scalars, flow mappings, block sequence skills, anchors/aliases, non-mapping frontmatter roots, and YAML syntax errors.
- Update YAML support docs so core frontmatter and sidecar parsing behavior match the current implementation.

## Why

This addresses the unresolved parser gap from #9: sidecars already used the `yaml` package, but core `.agent.md` frontmatter still used a custom subset parser that could mis-handle valid YAML constructs.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run tests/parse.test.ts`
- `pnpm test`
- `pnpm build`
- `pnpm test:matrix`
